### PR TITLE
Add debug log and wait for authentication code display

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -296,6 +296,11 @@ const states = [
       console.log(descriptionMessage);
 
       try {
+        debug("Waiting for authentication code to be displayed");
+        await page.waitForSelector("#idRichContext_DisplaySign", {
+          visible: true,
+          timeout: 5000,
+        });
         debug("Checking if authentication code is displayed");
         const authenticationCodeElement = await page.$(
           "#idRichContext_DisplaySign"


### PR DESCRIPTION
microsoft authenticatorに入力する数字がコンソールに表示されないバグを修正。