### PR TITLE
fix: Unreachable code in account selection logic

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -153,9 +153,9 @@ const states = [
       );
 
       const accounts = [
-        { message: aadTileMessage, selector: "#aadTileTitle" },
-        { message: msaTileMessage, selector: "#msaTileTitle" },
-      ];
+        aadTile ? { message: aadTileMessage, selector: "#aadTileTitle" } : null,
+        msaTile ? { message: msaTileMessage, selector: "#msaTileTitle" } : null,
+      ].filter((a): a is { message: string; selector: string } => a !== null);
 
       let account;
       if (accounts.length === 0) {


### PR DESCRIPTION
Closed #27 
Add null check for AAD and MSA tiles before rendering Use `.filter()` to remove null entries from tile accounts array