### PR TITLE
fix: clarify session duration validation message

### DIFF
--- a/src/configureProfileAsync.ts
+++ b/src/configureProfileAsync.ts
@@ -52,7 +52,7 @@ export async function configureProfileAsync(
       validate: (input): boolean | string => {
         input = Number(input);
         if (input > 0 && input <= 12) return true;
-        return "Duration hours must be between 0 and 12";
+        return "Duration hours must be between 1 and 12";
       },
     },
     {

--- a/src/login.ts
+++ b/src/login.ts
@@ -993,7 +993,7 @@ export const login = {
         validate: (input): boolean | string => {
           input = Number(input);
           if (input > 0 && input <= 12) return true;
-          return "Duration hours must be between 0 and 12";
+          return "Duration hours must be between 1 and 12";
         },
       });
     }


### PR DESCRIPTION
Summary:
- Align duration validation errors with the actual 1-12 hour constraint in CLI prompts.

Motivation:
- Reduce confusion when users enter 0 hours.

Testing:
- Not run (not requested).

Closes #58