### PR TITLE
feat: add verification code env and print output

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ https://snapcraft.io/az2aws
 | `--enable-chrome-seamless-sso` | Enable Azure AD Seamless SSO |
 | `--no-disable-extensions` | Keep browser extensions enabled |
 | `--disable-gpu` | Disable GPU acceleration |
+| `--print` | Print credentials to stdout instead of writing to files |
 | `--version (-v)` | Show version number |
 
 ## Usage
@@ -139,6 +140,7 @@ You can set defaults via environment variables (use with `--no-prompt`):
 - `AZURE_TENANT_ID` / `AZURE_APP_ID_URI` - Azure AD settings
 - `AZURE_DEFAULT_USERNAME` / `AZURE_DEFAULT_PASSWORD` - Credentials
 - `AZURE_DEFAULT_ROLE_ARN` / `AZURE_DEFAULT_DURATION_HOURS` - AWS role settings
+- `AZURE_VERIFICATION_CODE` - MFA verification code (used once per prompt)
 
 When using `--no-prompt` with multiple available roles, you must set
 `AZURE_DEFAULT_ROLE_ARN` (or configure `azure_default_role_arn`) so the CLI can

--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -24,7 +24,7 @@ export interface ProfileConfig {
   [key: string]: unknown;
 }
 
-interface ProfileCredentials {
+export interface ProfileCredentials {
   aws_access_key_id: string;
   aws_secret_access_key: string;
   aws_session_token: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ process.on("SIGTERM", () => process.exit(1));
 import { Command } from "commander";
 import { configureProfileAsync } from "./configureProfileAsync";
 import { login } from "./login";
+import { CLIError } from "./CLIError";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version } = require("../package.json") as { version: string };
@@ -56,6 +57,7 @@ program
     "--disable-gpu",
     "Tell Puppeteer to pass the --disable-gpu flag to Chromium"
   )
+  .option("--print", "Print credentials to stdout instead of writing to files")
   .parse(process.argv);
 
 const options = program.opts();
@@ -73,9 +75,14 @@ const enableChromeSeamlessSso = !!options.enableChromeSeamlessSso;
 const forceRefresh = !!options.forceRefresh;
 const noDisableExtensions = !options.disableExtensions;
 const disableGpu = !!options.disableGpu;
+const printCredentials = !!options.print;
 
 Promise.resolve()
   .then(() => {
+    if (options.allProfiles && printCredentials) {
+      throw new CLIError("--print cannot be used with --all-profiles.");
+    }
+
     if (options.allProfiles) {
       return login.loginAll(
         mode,
@@ -100,7 +107,8 @@ Promise.resolve()
       awsNoVerifySsl,
       enableChromeSeamlessSso,
       noDisableExtensions,
-      disableGpu
+      disableGpu,
+      printCredentials
     );
   })
   .catch((err: Error) => {

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -1503,7 +1503,8 @@ describe("login", () => {
           "base64-assertion",
           {
             roleArn: "arn:aws:iam::123456789012:role/TestRole",
-            principalArn: "arn:aws:iam::123456789012:saml-provider/TestProvider",
+            principalArn:
+              "arn:aws:iam::123456789012:saml-provider/TestProvider",
           },
           1,
           false,

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -248,6 +248,26 @@ describe("login", () => {
     });
   });
 
+  describe("_getVerificationCodeFromEnv", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it("should read verification code from environment variables", () => {
+      process.env.AZURE_VERIFICATION_CODE = "123456";
+
+      const result = login._getVerificationCodeFromEnv();
+
+      expect(result).toBe("123456");
+    });
+  });
+
   describe("_createLoginUrlAsync", () => {
     it("should create a valid Azure login URL", async () => {
       const appIdUri = "https://app.example.com";
@@ -1467,7 +1487,7 @@ describe("login", () => {
       expect(awsConfig.setProfileCredentialsAsync).not.toHaveBeenCalled();
     });
 
-    it("should handle credentials with missing optional fields", async () => {
+    it("should throw CLIError when credentials have missing fields", async () => {
       mockSend.mockResolvedValue({
         Credentials: {
           AccessKeyId: undefined,
@@ -1477,7 +1497,23 @@ describe("login", () => {
         },
       });
 
-      await login._assumeRoleAsync(
+      await expect(
+        login._assumeRoleAsync(
+          "test-profile",
+          "base64-assertion",
+          {
+            roleArn: "arn:aws:iam::123456789012:role/TestRole",
+            principalArn: "arn:aws:iam::123456789012:saml-provider/TestProvider",
+          },
+          1,
+          false,
+          "us-east-1"
+        )
+      ).rejects.toThrow("Unable to get complete security credentials from AWS");
+    });
+
+    it("should return credentials without writing when writeProfile is false", async () => {
+      const result = await login._assumeRoleAsync(
         "test-profile",
         "base64-assertion",
         {
@@ -1486,18 +1522,16 @@ describe("login", () => {
         },
         1,
         false,
-        "us-east-1"
+        "us-east-1",
+        false
       );
 
-      expect(awsConfig.setProfileCredentialsAsync).toHaveBeenCalledWith(
-        "test-profile",
-        {
-          aws_access_key_id: "",
-          aws_secret_access_key: "",
-          aws_session_token: "",
-          aws_expiration: "",
-        }
-      );
+      expect(result).toMatchObject({
+        aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        aws_secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        aws_session_token: "session-token",
+      });
+      expect(awsConfig.setProfileCredentialsAsync).not.toHaveBeenCalled();
     });
   });
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -117,12 +117,13 @@ export const login = {
         disableGpu
       );
       const roles = this._parseRolesFromSamlResponse(samlResponse);
-      const { role, durationHours } = await this._askUserForRoleAndDurationAsync(
-        roles,
-        noPrompt,
-        profile.azure_default_role_arn,
-        profile.azure_default_duration_hours
-      );
+      const { role, durationHours } =
+        await this._askUserForRoleAndDurationAsync(
+          roles,
+          noPrompt,
+          profile.azure_default_role_arn,
+          profile.azure_default_duration_hours
+        );
 
       const credentials = await this._assumeRoleAsync(
         profileName,
@@ -777,7 +778,9 @@ export const login = {
       !res.Credentials.Expiration
     ) {
       debug("Received incomplete security credentials from AWS");
-      throw new CLIError("Unable to get complete security credentials from AWS");
+      throw new CLIError(
+        "Unable to get complete security credentials from AWS"
+      );
     }
 
     const credentials: AwsCredentials = {

--- a/src/login.ts
+++ b/src/login.ts
@@ -8,14 +8,14 @@ import puppeteer, { Browser, HTTPRequest } from "puppeteer";
 import querystring from "querystring";
 import _debug from "debug";
 import { CLIError } from "./CLIError";
-import { awsConfig, ProfileConfig } from "./awsConfig";
+import { awsConfig, ProfileConfig, ProfileCredentials } from "./awsConfig";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { paths } from "./paths";
 import mkdirp from "mkdirp";
 import fs from "fs/promises";
 import { Agent } from "https";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
-import { states } from "./loginStates";
+import { states, getVerificationCodeFromEnv } from "./loginStates";
 
 const debug = _debug("az2aws");
 
@@ -41,6 +41,8 @@ interface Role {
   principalArn: string;
 }
 
+type AwsCredentials = ProfileCredentials;
+
 export const login = {
   async loginAsync(
     profileName: string,
@@ -51,78 +53,104 @@ export const login = {
     awsNoVerifySsl: boolean,
     enableChromeSeamlessSso: boolean,
     noDisableExtensions: boolean,
-    disableGpu: boolean
+    disableGpu: boolean,
+    printCredentials = false
   ): Promise<void> {
-    let headless, cliProxy;
-    if (mode === "cli") {
-      headless = true;
-      cliProxy = true;
-    } else if (mode === "gui") {
-      headless = false;
-      cliProxy = false;
-    } else if (mode === "debug") {
-      headless = false;
-      cliProxy = true;
-    } else {
-      throw new CLIError("Invalid mode");
-    }
+    const originalConsoleLog = console.log;
+    try {
+      if (printCredentials) {
+        console.log = (...args: unknown[]) => console.error(...args);
+      }
 
-    const profile = await this._loadProfileAsync(profileName);
-    console.log(
-      `Using AWS region ${profile.region || "(from AWS SDK defaults)"}`
-    );
-    if (profile.region && profile.region.startsWith("us-gov")) {
-      console.warn(
-        "GovCloud region detected in profile. Note: Other AWS CLI operations " +
-          "will use your AWS CLI default region. If needed, set it to match " +
-          "this GovCloud region (us-gov-west-1 or us-gov-east-1)."
+      let headless, cliProxy;
+      if (mode === "cli") {
+        headless = true;
+        cliProxy = true;
+      } else if (mode === "gui") {
+        headless = false;
+        cliProxy = false;
+      } else if (mode === "debug") {
+        headless = false;
+        cliProxy = true;
+      } else {
+        throw new CLIError("Invalid mode");
+      }
+
+      const profile = await this._loadProfileAsync(profileName);
+      console.log(
+        `Using AWS region ${profile.region || "(from AWS SDK defaults)"}`
       );
-    }
-    let assertionConsumerServiceURL = AWS_SAML_ENDPOINT;
-    if (profile.region && profile.region.startsWith("us-gov")) {
-      assertionConsumerServiceURL = AWS_GOV_SAML_ENDPOINT;
-    }
-    if (profile.region && profile.region.startsWith("cn-")) {
-      assertionConsumerServiceURL = AWS_CN_SAML_ENDPOINT;
-    }
+      if (profile.region && profile.region.startsWith("us-gov")) {
+        console.warn(
+          "GovCloud region detected in profile. Note: Other AWS CLI operations " +
+            "will use your AWS CLI default region. If needed, set it to match " +
+            "this GovCloud region (us-gov-west-1 or us-gov-east-1)."
+        );
+      }
+      let assertionConsumerServiceURL = AWS_SAML_ENDPOINT;
+      if (profile.region && profile.region.startsWith("us-gov")) {
+        assertionConsumerServiceURL = AWS_GOV_SAML_ENDPOINT;
+      }
+      if (profile.region && profile.region.startsWith("cn-")) {
+        assertionConsumerServiceURL = AWS_CN_SAML_ENDPOINT;
+      }
 
-    console.log("Using AWS SAML endpoint", assertionConsumerServiceURL);
+      console.log("Using AWS SAML endpoint", assertionConsumerServiceURL);
 
-    const loginUrl = await this._createLoginUrlAsync(
-      profile.azure_app_id_uri,
-      profile.azure_tenant_id,
-      assertionConsumerServiceURL
-    );
-    const samlResponse = await this._performLoginAsync(
-      loginUrl,
-      headless,
-      disableSandbox,
-      cliProxy,
-      noPrompt,
-      enableChromeNetworkService,
-      profile.azure_default_username,
-      profile.azure_default_password,
-      enableChromeSeamlessSso,
-      profile.azure_default_remember_me,
-      noDisableExtensions,
-      disableGpu
-    );
-    const roles = this._parseRolesFromSamlResponse(samlResponse);
-    const { role, durationHours } = await this._askUserForRoleAndDurationAsync(
-      roles,
-      noPrompt,
-      profile.azure_default_role_arn,
-      profile.azure_default_duration_hours
-    );
+      const loginUrl = await this._createLoginUrlAsync(
+        profile.azure_app_id_uri,
+        profile.azure_tenant_id,
+        assertionConsumerServiceURL
+      );
+      const samlResponse = await this._performLoginAsync(
+        loginUrl,
+        headless,
+        disableSandbox,
+        cliProxy,
+        noPrompt,
+        enableChromeNetworkService,
+        profile.azure_default_username,
+        profile.azure_default_password,
+        enableChromeSeamlessSso,
+        profile.azure_default_remember_me,
+        noDisableExtensions,
+        disableGpu
+      );
+      const roles = this._parseRolesFromSamlResponse(samlResponse);
+      const { role, durationHours } = await this._askUserForRoleAndDurationAsync(
+        roles,
+        noPrompt,
+        profile.azure_default_role_arn,
+        profile.azure_default_duration_hours
+      );
 
-    await this._assumeRoleAsync(
-      profileName,
-      samlResponse,
-      role,
-      durationHours,
-      awsNoVerifySsl,
-      profile.region
-    );
+      const credentials = await this._assumeRoleAsync(
+        profileName,
+        samlResponse,
+        role,
+        durationHours,
+        awsNoVerifySsl,
+        profile.region,
+        !printCredentials
+      );
+
+      if (printCredentials) {
+        if (!credentials) {
+          throw new CLIError("Unable to retrieve credentials.");
+        }
+
+        originalConsoleLog(
+          [
+            `aws_access_key_id=${credentials.aws_access_key_id}`,
+            `aws_secret_access_key=${credentials.aws_secret_access_key}`,
+            `aws_session_token=${credentials.aws_session_token}`,
+            `aws_expiration=${credentials.aws_expiration}`,
+          ].join("\n")
+        );
+      }
+    } finally {
+      console.log = originalConsoleLog;
+    }
   },
 
   async loginAll(
@@ -571,6 +599,10 @@ export const login = {
     return roles;
   },
 
+  _getVerificationCodeFromEnv(): string | undefined {
+    return getVerificationCodeFromEnv();
+  },
+
   /**
    * Ask the user for the role they want to use.
    * @param {Array.<{roleArn: string, principalArn: string}>} roles - The roles to pick from
@@ -684,8 +716,9 @@ export const login = {
     role: Role,
     durationHours: number,
     awsNoVerifySsl: boolean,
-    region: string
-  ): Promise<void> {
+    region: string,
+    writeProfile = true
+  ): Promise<AwsCredentials | undefined> {
     console.log(`Assuming role ${role.roleArn} in region ${region}...`);
     let stsOptions: STSClientConfig = {};
 
@@ -734,14 +767,30 @@ export const login = {
 
     if (!res.Credentials) {
       debug("Unable to get security credentials from AWS");
-      return;
+      return undefined;
     }
 
-    await awsConfig.setProfileCredentialsAsync(profileName, {
-      aws_access_key_id: res.Credentials.AccessKeyId ?? "",
-      aws_secret_access_key: res.Credentials.SecretAccessKey ?? "",
-      aws_session_token: res.Credentials.SessionToken ?? "",
-      aws_expiration: res.Credentials.Expiration?.toISOString() ?? "",
-    });
+    if (
+      !res.Credentials.AccessKeyId ||
+      !res.Credentials.SecretAccessKey ||
+      !res.Credentials.SessionToken ||
+      !res.Credentials.Expiration
+    ) {
+      debug("Received incomplete security credentials from AWS");
+      throw new CLIError("Unable to get complete security credentials from AWS");
+    }
+
+    const credentials: AwsCredentials = {
+      aws_access_key_id: res.Credentials.AccessKeyId,
+      aws_secret_access_key: res.Credentials.SecretAccessKey,
+      aws_session_token: res.Credentials.SessionToken,
+      aws_expiration: res.Credentials.Expiration.toISOString(),
+    };
+
+    if (writeProfile) {
+      await awsConfig.setProfileCredentialsAsync(profileName, credentials);
+    }
+
+    return credentials;
   },
 };

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -6,6 +6,9 @@ import { CLIError } from "./CLIError";
 
 const debug = _debug("az2aws");
 
+export const getVerificationCodeFromEnv = (): string | undefined =>
+  process.env.azure_verification_code || process.env.AZURE_VERIFICATION_CODE;
+
 export type StateHandler = (
   page: Page,
   selected: ElementHandle,
@@ -346,12 +349,19 @@ export const states: State[] = [
         console.log(descriptionMessage);
       }
 
-      const { verificationCode } = await inquirer.prompt([
-        {
-          name: "verificationCode",
-          message: "Verification Code:",
-        } as Question,
-      ]);
+      let verificationCode: string;
+      const envCode = getVerificationCodeFromEnv();
+      if (envCode) {
+        debug("Using verification code from environment");
+        verificationCode = envCode;
+      } else {
+        ({ verificationCode } = await inquirer.prompt([
+          {
+            name: "verificationCode",
+            message: "Verification Code:",
+          } as Question,
+        ]));
+      }
 
       debug("Focusing on verification code input");
       await page.focus(`input[name="otc"]`);


### PR DESCRIPTION
Summary:
- Add AZURE_VERIFICATION_CODE support for MFA input.
- Add --print to emit credentials to stdout and avoid file writes.
- Add tests and documentation.

Motivation:
- Enable fully automated MFA flows in scripts/CI.

Testing:
- Not run (not requested).

Closes #44