### PR TITLE
feat: add chromium executable override

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ https://snapcraft.io/az2aws
 | `--enable-chrome-seamless-sso` | Enable Azure AD Seamless SSO |
 | `--no-disable-extensions` | Keep browser extensions enabled |
 | `--disable-gpu` | Disable GPU acceleration |
+| `--chromium-executable <path>` | Override Chromium executable path |
 | `--version (-v)` | Show version number |
 
 ## Usage
@@ -146,6 +147,7 @@ To avoid storing passwords in bash history, use a leading space:
 Use your own Chrome installation by setting these environment variables:
 
 - `BROWSER_CHROME_BIN` - Path to Chrome executable
+- `CHROME_BIN` - Alternate env var for Chrome executable
 - `BROWSER_USER_DATA_DIR` - Chrome user data directory
 - `BROWSER_PROFILE_DIR` - Chrome profile name (e.g., "Default")
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ Use your own Chrome installation by setting these environment variables:
 - `BROWSER_USER_DATA_DIR` - Chrome user data directory
 - `BROWSER_PROFILE_DIR` - Chrome profile name (e.g., "Default")
 
+Chrome/Chromium executable precedence: `--chromium-executable` (highest),
+then `BROWSER_CHROME_BIN`, then `CHROME_BIN`.
+
 Example:
 
     # macOS

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ process.on("SIGTERM", () => process.exit(1));
 import { Command } from "commander";
 import { configureProfileAsync } from "./configureProfileAsync";
 import { login } from "./login";
+import { paths } from "./paths";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version } = require("../package.json") as { version: string };
@@ -57,6 +58,10 @@ program
     "--disable-gpu",
     "Tell Puppeteer to pass the --disable-gpu flag to Chromium"
   )
+  .option(
+    "--chromium-executable <path>",
+    "Specify a custom Chromium executable path"
+  )
   .parse(process.argv);
 
 const options = program.opts();
@@ -74,6 +79,11 @@ const enableChromeSeamlessSso = !!options.enableChromeSeamlessSso;
 const forceRefresh = !!options.forceRefresh;
 const noDisableExtensions = !options.disableExtensions;
 const disableGpu = !!options.disableGpu;
+const chromiumExecutable = options.chromiumExecutable as string | undefined;
+
+if (chromiumExecutable) {
+  paths.chromeBin = chromiumExecutable;
+}
 
 Promise.resolve()
   .then(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { Command } from "commander";
 import { configureProfileAsync } from "./configureProfileAsync";
 import { login } from "./login";
 import { paths } from "./paths";
+import { existsSync } from "fs";
+import { CLIError } from "./CLIError";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version } = require("../package.json") as { version: string };
@@ -82,6 +84,12 @@ const disableGpu = !!options.disableGpu;
 const chromiumExecutable = options.chromiumExecutable as string | undefined;
 
 if (chromiumExecutable) {
+  if (!existsSync(chromiumExecutable)) {
+    console.error(
+      `Error: Chromium executable not found at: ${chromiumExecutable}`
+    );
+    process.exit(1);
+  }
   paths.chromeBin = chromiumExecutable;
 }
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -69,6 +69,13 @@ describe("paths", () => {
     expect(paths.chromeBin).toBe("/opt/chrome");
   });
 
+  it("should prefer BROWSER_CHROME_BIN over CHROME_BIN", async () => {
+    process.env.BROWSER_CHROME_BIN = "/usr/bin/chrome";
+    process.env.CHROME_BIN = "/opt/chrome";
+    const { paths } = await import("./paths");
+    expect(paths.chromeBin).toBe("/usr/bin/chrome");
+  });
+
   it("should read BROWSER_USER_DATA_DIR from environment", async () => {
     process.env.BROWSER_USER_DATA_DIR = "/home/user/.config/chrome";
     const { paths } = await import("./paths");

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -62,6 +62,13 @@ describe("paths", () => {
     expect(paths.chromeBin).toBe("/usr/bin/chrome");
   });
 
+  it("should read CHROME_BIN when BROWSER_CHROME_BIN is not set", async () => {
+    delete process.env.BROWSER_CHROME_BIN;
+    process.env.CHROME_BIN = "/opt/chrome";
+    const { paths } = await import("./paths");
+    expect(paths.chromeBin).toBe("/opt/chrome");
+  });
+
   it("should read BROWSER_USER_DATA_DIR from environment", async () => {
     process.env.BROWSER_USER_DATA_DIR = "/home/user/.config/chrome";
     const { paths } = await import("./paths");

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -18,7 +18,7 @@ export const paths: {
   credentials:
     process.env.AWS_SHARED_CREDENTIALS_FILE || path.join(awsDir, "credentials"),
   chromium: path.join(awsDir, "chromium"),
-  chromeBin: process.env.BROWSER_CHROME_BIN,
+  chromeBin: process.env.BROWSER_CHROME_BIN || process.env.CHROME_BIN,
   userDataDir: process.env.BROWSER_USER_DATA_DIR,
   profileDir: process.env.BROWSER_PROFILE_DIR,
 };


### PR DESCRIPTION
Summary:
- Add --chromium-executable CLI option to override Chromium path.
- Support CHROME_BIN as a fallback env var and add tests/docs.

Motivation:
- Allow locked-down environments to use approved Chrome binaries.

Testing:
- Not run (not requested).

Closes #45