### PR TITLE
feat: allow env-only configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ To avoid storing passwords in bash history, use a leading space:
     HISTCONTROL=ignoreboth
      export AZURE_DEFAULT_PASSWORD=mypassword
 
+If no profile is configured, you can still run by providing at least
+`AZURE_TENANT_ID` and `AZURE_APP_ID_URI` via environment variables.
+
 #### Use an Existing Chrome Install and Profile
 
 Use your own Chrome installation by setting these environment variables:

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -432,6 +432,21 @@ describe("login", () => {
       );
     });
 
+    it("should allow env-only configuration when profile is missing", async () => {
+      process.env.AZURE_TENANT_ID = "env-tenant";
+      process.env.AZURE_APP_ID_URI = "env-app";
+      process.env.AZURE_DEFAULT_USERNAME = "env-user@example.com";
+
+      vi.mocked(awsConfig.getProfileConfigAsync).mockResolvedValue(undefined);
+
+      const result = await login._loadProfileAsync("missing");
+
+      expect(result.azure_tenant_id).toBe("env-tenant");
+      expect(result.azure_app_id_uri).toBe("env-app");
+      expect(result.azure_default_username).toBe("env-user@example.com");
+      expect(result.azure_default_remember_me).toBe(false);
+    });
+
     it("should throw CLIError when profile is missing required fields", async () => {
       vi.mocked(awsConfig.getProfileConfigAsync).mockResolvedValue({
         azure_tenant_id: "",

--- a/src/login.ts
+++ b/src/login.ts
@@ -588,13 +588,30 @@ export const login = {
   // Load the profile
   async _loadProfileAsync(profileName: string): Promise<ProfileConfig> {
     const profile = await awsConfig.getProfileConfigAsync(profileName);
-
-    if (!profile)
-      throw new CLIError(
-        `Unknown profile '${profileName}'. You must configure it first with --configure.`
-      );
-
     const env = this._loadProfileFromEnv();
+
+    if (!profile) {
+      if (!env.azure_tenant_id || !env.azure_app_id_uri) {
+        throw new CLIError(
+          `Unknown profile '${profileName}'. You must configure it first with --configure.`
+        );
+      }
+
+      console.log(
+        `Logging in with environment variables (no profile '${profileName}' found)...`
+      );
+      return {
+        azure_tenant_id: env.azure_tenant_id,
+        azure_app_id_uri: env.azure_app_id_uri,
+        azure_default_username: env.azure_default_username || "",
+        azure_default_password: env.azure_default_password,
+        azure_default_role_arn: env.azure_default_role_arn || "",
+        azure_default_duration_hours: env.azure_default_duration_hours || "",
+        azure_default_remember_me: false,
+        region: "",
+      };
+    }
+
     for (const prop in env) {
       if (env[prop]) {
         profile[prop] = env[prop] === null ? profile[prop] : env[prop];

--- a/src/login.ts
+++ b/src/login.ts
@@ -597,9 +597,12 @@ export const login = {
         );
       }
 
-      console.log(
-        `Logging in with environment variables (no profile '${profileName}' found)...`
+      console.warn(
+        `WARNING: Profile '${profileName}' not found. ` +
+          `Using environment variables only. ` +
+          `Credentials will NOT be saved to AWS profile '${profileName}'.`
       );
+      console.log("Logging in with environment variables...");
       return {
         azure_tenant_id: env.azure_tenant_id,
         azure_app_id_uri: env.azure_app_id_uri,


### PR DESCRIPTION
Summary:
- Permit running without a configured profile when required env vars are set.
- Add tests and docs for env-only usage.

Motivation:
- Support fully environment-driven configuration in CI/CD.

Testing:
- Not run (not requested).

Closes #47