### PR TITLE
feat: allow custom assertion consumer service URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ You can set defaults via environment variables (use with `--no-prompt`):
 - `AZURE_TENANT_ID` / `AZURE_APP_ID_URI` - Azure AD settings
 - `AZURE_DEFAULT_USERNAME` / `AZURE_DEFAULT_PASSWORD` - Credentials
 - `AZURE_DEFAULT_ROLE_ARN` / `AZURE_DEFAULT_DURATION_HOURS` - AWS role settings
+- `ASSERTION_CONSUMER_SERVICE_URL` - Custom SAML Assertion Consumer Service URL
 
 When using `--no-prompt` with multiple available roles, you must set
 `AZURE_DEFAULT_ROLE_ARN` (or configure `azure_default_role_arn`) so the CLI can

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ You can set defaults via environment variables (use with `--no-prompt`):
 - `AZURE_DEFAULT_USERNAME` / `AZURE_DEFAULT_PASSWORD` - Credentials
 - `AZURE_DEFAULT_ROLE_ARN` / `AZURE_DEFAULT_DURATION_HOURS` - AWS role settings
 - `ASSERTION_CONSUMER_SERVICE_URL` - Custom SAML Assertion Consumer Service URL
+  (Advanced: Use with caution. Misconfiguration may expose your SAML assertion.)
 
 When using `--no-prompt` with multiple available roles, you must set
 `AZURE_DEFAULT_ROLE_ARN` (or configure `azure_default_role_arn`) so the CLI can

--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -21,6 +21,7 @@ export interface ProfileConfig {
   azure_default_duration_hours: string;
   region: string;
   azure_default_remember_me: boolean;
+  assertion_consumer_service_url?: string;
   [key: string]: unknown;
 }
 

--- a/src/configureProfileAsync.ts
+++ b/src/configureProfileAsync.ts
@@ -1,5 +1,5 @@
 import inquirer, { Question } from "inquirer";
-import { awsConfig } from "./awsConfig";
+import { awsConfig, ProfileConfig } from "./awsConfig";
 
 export async function configureProfileAsync(
   profileName: string
@@ -60,11 +60,28 @@ export async function configureProfileAsync(
       message: "AWS Region:",
       default: profile && profile.region,
     },
+    {
+      name: "assertionConsumerServiceUrl",
+      message: "Assertion Consumer Service URL (optional):",
+      default: profile && profile.assertion_consumer_service_url,
+      validate: (input): boolean | string => {
+        if (!input) return true;
+        try {
+          const url = new URL(input);
+          if (url.protocol !== "https:" && url.protocol !== "http:") {
+            return "Assertion Consumer Service URL must start with http:// or https://";
+          }
+        } catch {
+          return "Assertion Consumer Service URL must be a valid URL";
+        }
+        return true;
+      },
+    },
   ];
 
   const answers = await inquirer.prompt(questions);
 
-  await awsConfig.setProfileConfigValuesAsync(profileName, {
+  const configValues: ProfileConfig = {
     azure_tenant_id: answers.tenantId as string,
     azure_app_id_uri: answers.appIdUri as string,
     azure_default_username: answers.username as string,
@@ -72,7 +89,16 @@ export async function configureProfileAsync(
     azure_default_duration_hours: answers.defaultDurationHours as string,
     azure_default_remember_me: (answers.rememberMe as string) === "true",
     region: answers.region as string,
-  });
+  };
+  const assertionConsumerServiceUrl = answers.assertionConsumerServiceUrl as
+    | string
+    | undefined;
+  if (assertionConsumerServiceUrl) {
+    configValues.assertion_consumer_service_url =
+      assertionConsumerServiceUrl;
+  }
+
+  await awsConfig.setProfileConfigValuesAsync(profileName, configValues);
 
   console.log("Profile saved.");
 }

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -104,6 +104,8 @@ describe("login", () => {
       delete process.env.AZURE_DEFAULT_ROLE_ARN;
       delete process.env.azure_default_duration_hours;
       delete process.env.AZURE_DEFAULT_DURATION_HOURS;
+      delete process.env.assertion_consumer_service_url;
+      delete process.env.ASSERTION_CONSUMER_SERVICE_URL;
 
       const result = login._loadProfileFromEnv();
       expect(result).toEqual({});
@@ -142,6 +144,8 @@ describe("login", () => {
       process.env.AZURE_DEFAULT_PASSWORD = "secret";
       process.env.AZURE_DEFAULT_ROLE_ARN = "arn:aws:iam::123456789:role/Test";
       process.env.AZURE_DEFAULT_DURATION_HOURS = "8";
+      process.env.ASSERTION_CONSUMER_SERVICE_URL =
+        "https://example.com/custom-acs";
 
       const result = login._loadProfileFromEnv();
       expect(result.azure_tenant_id).toBe("tenant-id");
@@ -152,6 +156,9 @@ describe("login", () => {
         "arn:aws:iam::123456789:role/Test"
       );
       expect(result.azure_default_duration_hours).toBe("8");
+      expect(result.assertion_consumer_service_url).toBe(
+        "https://example.com/custom-acs"
+      );
     });
   });
 
@@ -882,7 +889,7 @@ describe("login", () => {
       );
 
       expect(console.log).toHaveBeenCalledWith(
-        "Using AWS SAML endpoint",
+        "Using SAML Assertion Consumer Service URL",
         "https://signin.amazonaws.cn/saml"
       );
     });
@@ -911,7 +918,7 @@ describe("login", () => {
       );
 
       expect(console.log).toHaveBeenCalledWith(
-        "Using AWS SAML endpoint",
+        "Using SAML Assertion Consumer Service URL",
         "https://signin.amazonaws-us-gov.com/saml"
       );
     });
@@ -940,7 +947,7 @@ describe("login", () => {
       );
 
       expect(console.log).toHaveBeenCalledWith(
-        "Using AWS SAML endpoint",
+        "Using SAML Assertion Consumer Service URL",
         "https://signin.aws.amazon.com/saml"
       );
     });

--- a/src/login.ts
+++ b/src/login.ts
@@ -36,6 +36,27 @@ const getProxyUrl = (): string | undefined =>
   process.env.http_proxy ||
   process.env.HTTP_PROXY;
 
+const validateAssertionConsumerServiceURL = (value: string): void => {
+  if (/[\"<>]/.test(value)) {
+    throw new CLIError(
+      "Assertion Consumer Service URL contains invalid characters."
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new CLIError("Assertion Consumer Service URL must be a valid URL.");
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new CLIError(
+      "Assertion Consumer Service URL must start with http:// or https://."
+    );
+  }
+};
+
 interface Role {
   roleArn: string;
   principalArn: string;
@@ -78,15 +99,28 @@ export const login = {
           "this GovCloud region (us-gov-west-1 or us-gov-east-1)."
       );
     }
-    let assertionConsumerServiceURL = AWS_SAML_ENDPOINT;
-    if (profile.region && profile.region.startsWith("us-gov")) {
-      assertionConsumerServiceURL = AWS_GOV_SAML_ENDPOINT;
-    }
-    if (profile.region && profile.region.startsWith("cn-")) {
-      assertionConsumerServiceURL = AWS_CN_SAML_ENDPOINT;
+    let assertionConsumerServiceURL =
+      profile.assertion_consumer_service_url || AWS_SAML_ENDPOINT;
+    if (!profile.assertion_consumer_service_url) {
+      if (profile.region && profile.region.startsWith("us-gov")) {
+        assertionConsumerServiceURL = AWS_GOV_SAML_ENDPOINT;
+      }
+      if (profile.region && profile.region.startsWith("cn-")) {
+        assertionConsumerServiceURL = AWS_CN_SAML_ENDPOINT;
+      }
+    } else {
+      validateAssertionConsumerServiceURL(assertionConsumerServiceURL);
+      console.warn(
+        "WARNING: Using custom Assertion Consumer Service URL. " +
+          "Ensure this URL is trusted. Misconfiguration may expose your " +
+          "SAML assertion to unintended recipients."
+      );
     }
 
-    console.log("Using AWS SAML endpoint", assertionConsumerServiceURL);
+    console.log(
+      "Using SAML Assertion Consumer Service URL",
+      assertionConsumerServiceURL
+    );
 
     const loginUrl = await this._createLoginUrlAsync(
       profile.azure_app_id_uri,
@@ -177,6 +211,7 @@ export const login = {
       "azure_default_password",
       "azure_default_role_arn",
       "azure_default_duration_hours",
+      "assertion_consumer_service_url",
     ];
     for (let i = 0; i < options.length; i++) {
       const opt = options[i];


### PR DESCRIPTION
Summary:
- Add assertion_consumer_service_url support via config/env and configure prompt.
- Use custom ACS URL when provided and add tests/docs.

Motivation:
- Support orgs that require non-standard SAML ACS destinations.

Testing:
- Not run (not requested).

Closes #48