### PR TITLE
feat: add shell script hooks for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ To avoid storing passwords in bash history, use a leading space:
     HISTCONTROL=ignoreboth
      export AZURE_DEFAULT_PASSWORD=mypassword
 
+#### Shell Script Hooks
+
+You can provide authentication values via executable scripts. If a script exists
+and exits with code 0, its stdout is used:
+
+- `~/.aws/.aws-azure-login.username.sh` - Username
+- `~/.aws/.aws-azure-login.password.sh` - Password
+- `~/.aws/.aws-azure-login.static-challenge.sh` - MFA code
+
 #### Use an Existing Chrome Install and Profile
 
 Use your own Chrome installation by setting these environment variables:

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ and exits with code 0, its stdout is used:
 - `~/.aws/.aws-azure-login.password.sh` - Password
 - `~/.aws/.aws-azure-login.static-challenge.sh` - MFA code
 
+Notes:
+- Hooks take precedence over environment variables and prompts.
+- Scripts must be executable and exit with code 0; non-zero exits are treated as failures.
+- Trailing newlines are removed from stdout; leading/trailing spaces are preserved.
+- Hook scripts are Unix/macOS-only (paths end in `.sh`).
+
 #### Use an Existing Chrome Install and Profile
 
 Use your own Chrome installation by setting these environment variables:

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { login } from "./login";
 import { CLIError } from "./CLIError";
+import fs from "fs";
+import os from "os";
+import path from "path";
 
 vi.mock("inquirer", () => ({
   default: {
@@ -245,6 +248,105 @@ describe("login", () => {
       const roles = login._parseRolesFromSamlResponse(samlAssertion);
 
       expect(roles).toHaveLength(0);
+    });
+  });
+
+  describe("_runHookScript", () => {
+    const createTempScript = (content: string, mode: number): string => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "az2aws-hook-"));
+      const scriptPath = path.join(tempDir, "hook.sh");
+      fs.writeFileSync(scriptPath, content);
+      fs.chmodSync(scriptPath, mode);
+      return scriptPath;
+    };
+
+    const cleanupTempScript = (scriptPath: string) => {
+      fs.rmSync(path.dirname(scriptPath), { recursive: true, force: true });
+    };
+
+    it("should return undefined when script does not exist", async () => {
+      const result = await login._runHookScript(
+        path.join(os.tmpdir(), "az2aws-missing-hook.sh")
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it("should read output from an executable script", async () => {
+      const scriptPath = createTempScript(
+        "#!/bin/sh\necho hook-value\n",
+        0o700
+      );
+
+      try {
+        const result = await login._runHookScript(scriptPath);
+        expect(result).toBe("hook-value");
+      } finally {
+        cleanupTempScript(scriptPath);
+      }
+    });
+
+    it("should throw when script is not executable", async () => {
+      const scriptPath = createTempScript("#!/bin/sh\necho nope\n", 0o600);
+
+      try {
+        await expect(login._runHookScript(scriptPath)).rejects.toThrow(
+          CLIError
+        );
+      } finally {
+        cleanupTempScript(scriptPath);
+      }
+    });
+
+    it("should throw when script returns empty output", async () => {
+      const scriptPath = createTempScript("#!/bin/sh\n", 0o700);
+
+      try {
+        await expect(login._runHookScript(scriptPath)).rejects.toThrow(
+          CLIError
+        );
+      } finally {
+        cleanupTempScript(scriptPath);
+      }
+    });
+
+    it("should throw when script exits non-zero", async () => {
+      const scriptPath = createTempScript("#!/bin/sh\nexit 1\n", 0o700);
+
+      try {
+        await expect(login._runHookScript(scriptPath)).rejects.toThrow();
+      } finally {
+        cleanupTempScript(scriptPath);
+      }
+    });
+
+    it("should throw when script has group write permission", async () => {
+      const scriptPath = createTempScript(
+        "#!/bin/sh\necho insecure\n",
+        0o720
+      );
+
+      try {
+        await expect(login._runHookScript(scriptPath)).rejects.toThrow(
+          /insecure permissions/
+        );
+      } finally {
+        cleanupTempScript(scriptPath);
+      }
+    });
+
+    it("should throw when script has world write permission", async () => {
+      const scriptPath = createTempScript(
+        "#!/bin/sh\necho insecure\n",
+        0o702
+      );
+
+      try {
+        await expect(login._runHookScript(scriptPath)).rejects.toThrow(
+          /insecure permissions/
+        );
+      } finally {
+        cleanupTempScript(scriptPath);
+      }
     });
   });
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -15,7 +15,7 @@ import mkdirp from "mkdirp";
 import fs from "fs/promises";
 import { Agent } from "https";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
-import { states } from "./loginStates";
+import { states, runHookScript, runHookScriptSensitive } from "./loginStates";
 
 const debug = _debug("az2aws");
 
@@ -569,6 +569,14 @@ export const login = {
       .get();
     debug("Found roles", roles);
     return roles;
+  },
+
+  _runHookScript(scriptPath: string): Promise<string | undefined> {
+    return runHookScript(scriptPath);
+  },
+
+  _runHookScriptSensitive(scriptPath: string): Promise<string | undefined> {
+    return runHookScriptSensitive(scriptPath);
   },
 
   /**

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -3,8 +3,141 @@ import inquirer, { Question } from "inquirer";
 import { Page, ElementHandle } from "puppeteer";
 import _debug from "debug";
 import { CLIError } from "./CLIError";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import util from "util";
+import { execFile } from "child_process";
 
 const debug = _debug("az2aws");
+
+const execFileAsync = util.promisify(execFile);
+export const hookScripts = {
+  username: path.join(os.homedir(), ".aws", ".aws-azure-login.username.sh"),
+  password: path.join(os.homedir(), ".aws", ".aws-azure-login.password.sh"),
+  mfa: path.join(os.homedir(), ".aws", ".aws-azure-login.static-challenge.sh"),
+};
+
+const logHookStderr = (
+  scriptPath: string,
+  stderr: string,
+  context: "success" | "failure"
+): void => {
+  const trimmed = stderr.trim();
+  if (!trimmed) {
+    return;
+  }
+  debug(`Hook script stderr on ${context} (${scriptPath}): ${trimmed}`);
+};
+
+/**
+ * Validate hook script security: ownership and permissions.
+ * - Script must be owned by the current user
+ * - Script must not be writable by group or others
+ */
+const validateHookScriptSecurity = async (scriptPath: string): Promise<void> => {
+  const stat = await fs.promises.stat(scriptPath);
+  const currentUid = process.getuid?.();
+
+  // Check ownership (skip on Windows where getuid is not available)
+  if (currentUid !== undefined && stat.uid !== currentUid) {
+    throw new CLIError(
+      `Hook script is not owned by current user: ${scriptPath}. ` +
+        `This is a security risk. Please ensure you own the script.`
+    );
+  }
+
+  // Check that group and others cannot write to the script (mode & 022)
+  const unsafePermissions = stat.mode & 0o022;
+  if (unsafePermissions) {
+    throw new CLIError(
+      `Hook script has insecure permissions: ${scriptPath}. ` +
+        `Group or others have write access. Please run: chmod go-w "${scriptPath}"`
+    );
+  }
+};
+
+/**
+ * Run a hook script and return its stdout output.
+ * Logs stderr for debugging purposes.
+ * Use runHookScriptSensitive for hooks that return sensitive data.
+ */
+export const runHookScript = async (
+  scriptPath: string
+): Promise<string | undefined> => {
+  try {
+    await fs.promises.access(scriptPath, fs.constants.F_OK);
+  } catch {
+    return undefined;
+  }
+
+  try {
+    await fs.promises.access(scriptPath, fs.constants.X_OK);
+  } catch {
+    throw new CLIError(`Hook script is not executable: ${scriptPath}`);
+  }
+
+  // Validate script ownership and permissions
+  await validateHookScriptSecurity(scriptPath);
+
+  try {
+    const { stdout, stderr } = await execFileAsync(scriptPath, [], {
+      env: process.env,
+      timeout: 30000,
+      maxBuffer: 10 * 1024,
+    });
+    if (stderr) {
+      logHookStderr(scriptPath, stderr, "success");
+    }
+    const output = stdout.replace(/(?:\r?\n)+$/, "");
+    if (!output) {
+      throw new CLIError(`Hook script returned empty output: ${scriptPath}`);
+    }
+    return output;
+  } catch (err) {
+    if (err && typeof err === "object" && "stderr" in err) {
+      const errorStderr = err.stderr;
+      if (typeof errorStderr === "string") {
+        logHookStderr(scriptPath, errorStderr, "failure");
+      }
+    }
+    throw err;
+  }
+};
+
+/**
+ * Run a hook script for sensitive data (password, MFA).
+ * Does NOT log stderr to prevent leaking sensitive information.
+ */
+export const runHookScriptSensitive = async (
+  scriptPath: string
+): Promise<string | undefined> => {
+  try {
+    await fs.promises.access(scriptPath, fs.constants.F_OK);
+  } catch {
+    return undefined;
+  }
+
+  try {
+    await fs.promises.access(scriptPath, fs.constants.X_OK);
+  } catch {
+    throw new CLIError(`Hook script is not executable: ${scriptPath}`);
+  }
+
+  // Validate script ownership and permissions
+  await validateHookScriptSecurity(scriptPath);
+
+  const { stdout } = await execFileAsync(scriptPath, [], {
+    env: process.env,
+    timeout: 30000,
+    maxBuffer: 10 * 1024,
+  });
+  const output = stdout.replace(/(?:\r?\n)+$/, "");
+  if (!output) {
+    throw new CLIError(`Hook script returned empty output: ${scriptPath}`);
+  }
+  return output;
+};
 
 export type StateHandler = (
   page: Page,
@@ -52,7 +185,11 @@ export const states: State[] = [
 
       let username;
 
-      if (noPrompt && defaultUsername) {
+      const hookUsername = await runHookScript(hookScripts.username);
+      if (hookUsername) {
+        debug("Using username from hook script");
+        username = hookUsername;
+      } else if (noPrompt && defaultUsername) {
         debug("Not prompting user for username");
         username = defaultUsername;
       } else {
@@ -239,7 +376,11 @@ export const states: State[] = [
 
       let password;
 
-      if (noPrompt && defaultPassword) {
+      const hookPassword = await runHookScriptSensitive(hookScripts.password);
+      if (hookPassword) {
+        debug("Using password from hook script");
+        password = hookPassword;
+      } else if (noPrompt && defaultPassword) {
         debug("Not prompting user for password");
         password = defaultPassword;
       } else {
@@ -346,12 +487,19 @@ export const states: State[] = [
         console.log(descriptionMessage);
       }
 
-      const { verificationCode } = await inquirer.prompt([
-        {
-          name: "verificationCode",
-          message: "Verification Code:",
-        } as Question,
-      ]);
+      let verificationCode;
+      const hookCode = await runHookScriptSensitive(hookScripts.mfa);
+      if (hookCode) {
+        debug("Using verification code from hook script");
+        verificationCode = hookCode;
+      } else {
+        ({ verificationCode } = await inquirer.prompt([
+          {
+            name: "verificationCode",
+            message: "Verification Code:",
+          } as Question,
+        ]));
+      }
 
       debug("Focusing on verification code input");
       await page.focus(`input[name="otc"]`);


### PR DESCRIPTION
Summary:
- Add hook scripts for username, password, and MFA code retrieval.
- Validate executability, capture output, and add tests/docs.

Motivation:
- Integrate with password managers and custom auth flows.

Testing:
- Not run (not requested).

Closes #49