### PR TITLE
docs: add CLI page state troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you see "Unable to recognize page state!", Azure's login pages may have
 changed. Try:
 
 - `--mode gui` or `--mode debug`
-- Updating selectors by filing an issue with the screenshot (`az2aws-unrecognized-state.png`)
+- Filing an issue with the screenshot (`az2aws-unrecognized-state.png`) to help maintainers update selectors
 
 ## Automation
 


### PR DESCRIPTION
Summary:
- Document steps to take when CLI state detection fails, including gui/debug modes and screenshots.

Motivation:
- Provide guidance when Azure login pages change selectors.

Testing:
- Not run (not requested).

Closes #38