### PR TITLE
perf: optimize keyboard input clearing with select + backspace

### DIFF
--- a/src/loginStates.test.ts
+++ b/src/loginStates.test.ts
@@ -19,6 +19,7 @@ import inquirer from "inquirer";
 // Helper to create mock page
 const createMockPage = () => ({
   $: vi.fn(),
+  $eval: vi.fn().mockResolvedValue(undefined),
   evaluate: vi.fn(),
   waitForSelector: vi.fn().mockResolvedValue(undefined),
   focus: vi.fn().mockResolvedValue(undefined),
@@ -169,7 +170,11 @@ describe("loginStates", () => {
       // Should focus on username input
       expect(mockPage.focus).toHaveBeenCalledWith('input[name="loginfmt"]');
 
-      // Should clear input with backspaces (implementation detail: multiple times)
+      // Should select all text and delete with single backspace
+      expect(mockPage.$eval).toHaveBeenCalledWith(
+        'input[name="loginfmt"]',
+        expect.any(Function)
+      );
       expect(mockPage.keyboard.press).toHaveBeenCalledWith("Backspace");
 
       // Should type username
@@ -732,7 +737,11 @@ describe("loginStates", () => {
       );
 
       expect(mockPage.focus).toHaveBeenCalledWith('input[name="otc"]');
-      // Should clear input with backspaces (implementation detail: multiple times)
+      // Should select all text and delete with single backspace
+      expect(mockPage.$eval).toHaveBeenCalledWith(
+        'input[name="otc"]',
+        expect.any(Function)
+      );
       expect(mockPage.keyboard.press).toHaveBeenCalledWith("Backspace");
       expect(mockPage.keyboard.type).toHaveBeenCalledWith("999999");
       consoleSpy.mockRestore();

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -77,9 +77,10 @@ export const states: State[] = [
       await page.focus(`input[name="loginfmt"]`);
 
       debug("Clearing input");
-      for (let i = 0; i < 100; i++) {
-        await page.keyboard.press("Backspace");
-      }
+      await page.$eval('input[name="loginfmt"]', (el) => {
+        el.select();
+      });
+      await page.keyboard.press("Backspace");
 
       debug("Typing username");
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -357,9 +358,10 @@ export const states: State[] = [
       await page.focus(`input[name="otc"]`);
 
       debug("Clearing input");
-      for (let i = 0; i < 100; i++) {
-        await page.keyboard.press("Backspace");
-      }
+      await page.$eval('input[name="otc"]', (el) => {
+        el.select();
+      });
+      await page.keyboard.press("Backspace");
 
       debug("Typing verification code");
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument


### PR DESCRIPTION
## Summary
- Replace 100 sequential backspace key presses with `HTMLInputElement.select()` + single `Backspace`
- Reduces ~100 async CDP round-trips to just 2 per input field, eliminating 100-500ms of unnecessary delay
- Affects username input clearing and TFA verification code input clearing

## Changes
- `src/loginStates.ts` - Replace backspace loops with `page.$eval()` select + single backspace
- `src/loginStates.test.ts` - Add `$eval` mock and update assertions

## Approach
Uses `page.$eval(selector, el => el.select())` to select all text in the input field via the DOM API, then sends a single `Backspace` keypress to delete the selected text. This approach is:
- **Cross-platform**: `HTMLInputElement.select()` is a standard DOM API, no OS-specific keyboard shortcuts needed
- **SPA-compatible**: The `Backspace` keypress fires `input` events, maintaining framework state synchronization
- **Minimal**: Only 2 CDP round-trips instead of 100

## Test plan
- [x] All 166 existing tests pass
- [x] TypeScript compilation succeeds
- [x] ESLint and Prettier checks pass

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)