### PR TITLE
Update workflows to use pnpm cache and remove standalone option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
-        with:
-          standalone: true
       - uses: actions/setup-node@v5
         with:
           node-version: 24
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test:coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
-        with:
-          standalone: true
       - uses: actions/setup-node@v5
         with:
           node-version: 24
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test
@@ -50,6 +49,7 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
 
       - name: Publish to npm with provenance (OIDC)
         run: npm publish


### PR DESCRIPTION
Disable package-manager-cache in npm publish step to avoid conflicts with pnpm caching.