### PR TITLE
feat: notify new available version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,9 @@ const disableGpu = !!options.disableGpu;
 const incognito = !!options.incognito;
 
 // Start the update lookup immediately, but only print after the main flow ends.
-const updateCheckPromise = checkForUpdate(version);
+const updateCheckPromise = checkForUpdate(version, {
+  useColor: process.stderr.isTTY && !process.env.NO_COLOR,
+});
 
 async function runAsync(): Promise<void> {
   let exitCode = 0;

--- a/src/updateNotifier.test.ts
+++ b/src/updateNotifier.test.ts
@@ -61,6 +61,22 @@ describe("checkForUpdate", () => {
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 
+  it("should colorize the update message when color output is enabled", async () => {
+    const req = createMockRequest();
+    vi.mocked(https.get).mockImplementation((_url, _opts, cb) => {
+      const callback = cb as (res: EventEmitter) => void;
+      callback(createMockResponse(JSON.stringify({ version: "2.0.0" })));
+      return req as never;
+    });
+
+    const message = await checkForUpdate("1.5.0", { useColor: true });
+
+    expect(message).toContain("\u001b[33m");
+    expect(message).toContain("\u001b[0m");
+    expect(message).toContain("Update available!");
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
   it("should not show message when already on latest version", async () => {
     const req = createMockRequest();
     vi.mocked(https.get).mockImplementation((_url, _opts, cb) => {

--- a/src/updateNotifier.ts
+++ b/src/updateNotifier.ts
@@ -6,6 +6,8 @@ import os from "os";
 const PACKAGE_NAME = "az2aws";
 const CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
 const FAKE_LATEST_VERSION_ENV = "AZ2AWS_FAKE_LATEST_VERSION";
+const ANSI_YELLOW = "\u001b[33m";
+const ANSI_RESET = "\u001b[0m";
 
 type InstallMethod = "mise" | "snap" | "unknown";
 
@@ -18,6 +20,7 @@ interface CheckForUpdateOptions {
   env?: NodeJS.ProcessEnv;
   executablePath?: string;
   installMethod?: InstallMethod;
+  useColor?: boolean;
 }
 
 function getCachePath(): string {
@@ -131,13 +134,16 @@ function createUpdateMessage(
   currentVersion: string,
   latestVersion: string,
   installMethod: InstallMethod,
+  useColor = false,
 ): string {
-  return [
+  const message = [
     "",
     `Update available! ${currentVersion} -> ${latestVersion}`,
     getUpdateInstructions(installMethod),
     "",
   ].join("\n");
+
+  return useColor ? `${ANSI_YELLOW}${message}${ANSI_RESET}` : message;
 }
 
 export async function checkForUpdate(
@@ -166,7 +172,12 @@ export async function checkForUpdate(
         options.installMethod ??
         detectInstallMethod(env, options.executablePath ?? process.argv[1]);
 
-      return createUpdateMessage(currentVersion, latestVersion, installMethod);
+      return createUpdateMessage(
+        currentVersion,
+        latestVersion,
+        installMethod,
+        options.useColor ?? false,
+      );
     }
   } catch {
     // Silently ignore update check failures


### PR DESCRIPTION
  ## Summary

  Add an update notification for `az2aws` and make the CLI output safer and easier to notice.

  ## What Changed

  - Added update checking against the npm registry with a cached result to avoid frequent network calls.
  - Show an update notice only after the main CLI flow completes successfully.
  - Send the update notice to `stderr` instead of `stdout` so it does not interfere with normal command output.
  - Color the update notice yellow when running in an interactive terminal.
  - Default the suggested upgrade command to `npm install -g az2aws` when the install method cannot be detected.
  - Added `AZ2AWS_FAKE_LATEST_VERSION` for temporary local verification of the update notice without depending on the
  actual registry response.
  - Added tests for the update message content, install method handling, fake version override, and colored output.

  ## Why

  - Avoid breaking or polluting normal CLI output.
  - Prevent update notices from interrupting prompts or appearing during failed runs.
  - Make the notice more visible in interactive use while keeping redirected output clean.
  - Make local/manual verification easier during development.