### PR TITLE
fix: harden all-profiles refresh flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ https://snapcraft.io/az2aws
 | Option | Description |
 |--------|-------------|
 | `--profile (-p)` | Profile name to use. Default: `default` or `AWS_PROFILE` |
-| `--all-profiles (-a)` | Run for all configured profiles |
+| `--all-profiles (-a)` | Run for all configured profiles. Best used with `--no-prompt` |
 | `--force-refresh (-f)` | Force refresh even if credentials are valid |
 | `--configure (-c)` | Configure the profile |
 | `--mode (-m) <mode>` | `cli` (default), `gui`, or `debug` |
@@ -227,8 +227,15 @@ changed. Try:
 
 Renew all profiles at once:
 
-    az2aws --all-profiles
-    az2aws --all-profiles --no-prompt    # With "Stay logged in" enabled
+    az2aws --all-profiles --no-prompt
+
+`--all-profiles` is intended for unattended refresh flows. Interactive use is
+deprecated and may be removed in a future release. Configure per-profile
+defaults such as `azure_default_role_arn` and `azure_default_duration_hours`
+before using `--all-profiles --no-prompt`.
+
+If one profile fails to refresh, az2aws logs the failure, continues with the
+remaining profiles, and exits non-zero with a summary at the end.
 
 Credentials are only refreshed if expiring within 11 minutes - safe to run as a cron job.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,10 @@ program
     "-p, --profile <name>",
     "The name of the profile to log in with (or configure)",
   )
-  .option("-a, --all-profiles", "Run for all configured profiles")
+  .option(
+    "-a, --all-profiles",
+    "Run for all configured profiles (prefer with --no-prompt)",
+  )
   .option(
     "-f, --force-refresh",
     "Force a credential refresh, even if they are still valid",

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -968,6 +968,7 @@ describe("login", () => {
       vi.clearAllMocks();
       vi.spyOn(console, "log").mockImplementation(() => {});
       vi.spyOn(console, "warn").mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
     afterEach(() => {
@@ -994,6 +995,27 @@ describe("login", () => {
       );
 
       expect(loginAsyncSpy).not.toHaveBeenCalled();
+    });
+
+    it("should warn when --all-profiles is used without --no-prompt", async () => {
+      vi.mocked(awsConfig.getAllProfileNames).mockResolvedValue([]);
+
+      await login.loginAll(
+        "cli",
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+      );
+
+      expect(console.warn).toHaveBeenCalledWith(
+        "WARNING: Interactive use of --all-profiles is deprecated. Prefer --all-profiles --no-prompt with per-profile defaults configured.",
+      );
     });
 
     it("should iterate over all profiles with forceRefresh=true and skip expiration check", async () => {
@@ -1128,11 +1150,16 @@ describe("login", () => {
       expect(loginAsyncSpy).not.toHaveBeenCalled();
     });
 
-    it("should propagate error when loginAsync throws", async () => {
-      vi.mocked(awsConfig.getAllProfileNames).mockResolvedValue(["profile1"]);
+    it("should continue with other profiles when loginAsync throws and report failures at the end", async () => {
+      vi.mocked(awsConfig.getAllProfileNames).mockResolvedValue([
+        "profile1",
+        "profile2",
+      ]);
       vi.mocked(awsConfig.isProfileAboutToExpireAsync).mockResolvedValue(true);
-      const loginError = new Error("Login failed");
-      vi.spyOn(login, "loginAsync").mockRejectedValue(loginError);
+      const loginAsyncSpy = vi
+        .spyOn(login, "loginAsync")
+        .mockRejectedValueOnce(new Error("Login failed"))
+        .mockResolvedValueOnce(undefined);
 
       const error = await login
         .loginAll(
@@ -1142,23 +1169,31 @@ describe("login", () => {
           false,
           false,
           false,
-          true,
+          false,
           false,
           false,
           false,
         )
         .catch((e: unknown) => e);
 
-      expect(error).toBe(loginError);
-      expect((error as Error).message).toBe("Login failed");
+      expect(loginAsyncSpy).toHaveBeenCalledTimes(2);
+      expect(console.error).toHaveBeenCalledWith(
+        "Failed to refresh profile 'profile1': Login failed",
+      );
+      expect(error).toBeInstanceOf(CLIError);
+      expect((error as Error).message).toBe(
+        "Failed to refresh 1 profile: profile1.",
+      );
     });
 
-    it("should propagate error when isProfileAboutToExpireAsync throws", async () => {
-      vi.mocked(awsConfig.getAllProfileNames).mockResolvedValue(["profile1"]);
-      const expireError = new Error("Failed to check expiration");
-      vi.mocked(awsConfig.isProfileAboutToExpireAsync).mockRejectedValue(
-        expireError,
-      );
+    it("should continue with other profiles when expiration checks fail and report failures at the end", async () => {
+      vi.mocked(awsConfig.getAllProfileNames).mockResolvedValue([
+        "profile1",
+        "profile2",
+      ]);
+      vi.mocked(awsConfig.isProfileAboutToExpireAsync)
+        .mockRejectedValueOnce(new Error("Failed to check expiration"))
+        .mockResolvedValueOnce(true);
       const loginAsyncSpy = vi
         .spyOn(login, "loginAsync")
         .mockResolvedValue(undefined);
@@ -1178,9 +1213,26 @@ describe("login", () => {
         )
         .catch((e: unknown) => e);
 
-      expect(error).toBe(expireError);
-      expect((error as Error).message).toBe("Failed to check expiration");
-      expect(loginAsyncSpy).not.toHaveBeenCalled();
+      expect(loginAsyncSpy).toHaveBeenCalledTimes(1);
+      expect(loginAsyncSpy).toHaveBeenCalledWith(
+        "profile2",
+        "cli",
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        "Failed to refresh profile 'profile1': Failed to check expiration",
+      );
+      expect(error).toBeInstanceOf(CLIError);
+      expect((error as Error).message).toBe(
+        "Failed to refresh 1 profile: profile1.",
+      );
     });
   });
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -159,29 +159,50 @@ export const login = {
     incognito = false,
   ): Promise<void> {
     const profiles = await awsConfig.getAllProfileNames();
+    const failedProfiles: string[] = [];
+
+    if (!noPrompt) {
+      console.warn(
+        "WARNING: Interactive use of --all-profiles is deprecated. Prefer --all-profiles --no-prompt with per-profile defaults configured.",
+      );
+    }
 
     for (const profile of profiles) {
-      debug(`Check if profile ${profile} is expired or is about to expire`);
-      if (
-        !forceRefresh &&
-        !(await awsConfig.isProfileAboutToExpireAsync(profile))
-      ) {
-        debug(`Profile ${profile} not yet due for refresh.`);
-        continue;
-      }
+      try {
+        debug(`Check if profile ${profile} is expired or is about to expire`);
+        if (
+          !forceRefresh &&
+          !(await awsConfig.isProfileAboutToExpireAsync(profile))
+        ) {
+          debug(`Profile ${profile} not yet due for refresh.`);
+          continue;
+        }
 
-      debug(`Run login for profile: ${profile}`);
-      await this.loginAsync(
-        profile,
-        mode,
-        disableSandbox,
-        noPrompt,
-        enableChromeNetworkService,
-        awsNoVerifySsl,
-        enableChromeSeamlessSso,
-        noDisableExtensions,
-        disableGpu,
-        incognito,
+        debug(`Run login for profile: ${profile}`);
+        await this.loginAsync(
+          profile,
+          mode,
+          disableSandbox,
+          noPrompt,
+          enableChromeNetworkService,
+          awsNoVerifySsl,
+          enableChromeSeamlessSso,
+          noDisableExtensions,
+          disableGpu,
+          incognito,
+        );
+      } catch (err: unknown) {
+        failedProfiles.push(profile);
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`Failed to refresh profile '${profile}': ${message}`);
+      }
+    }
+
+    if (failedProfiles.length > 0) {
+      throw new CLIError(
+        `Failed to refresh ${failedProfiles.length} profile${
+          failedProfiles.length === 1 ? "" : "s"
+        }: ${failedProfiles.join(", ")}.`,
       );
     }
   },


### PR DESCRIPTION
## Summary
- deprecate interactive `--all-profiles` usage and steer users toward `--no-prompt`
- continue refreshing remaining profiles when one profile fails, then exit non-zero with a summary
- cover the new behavior with tests and document the intended unattended workflow

## Testing
- pnpm test -- src/login.test.ts
- pnpm lint
- pnpm build