### PR TITLE
fix: enforce whole number validation for session duration hours

### DIFF
--- a/src/configureProfileAsync.test.ts
+++ b/src/configureProfileAsync.test.ts
@@ -331,13 +331,19 @@ describe("configureProfileAsync", () => {
       expect(durationHoursQuestion.validate(6)).toBe(true);
       expect(durationHoursQuestion.validate("8")).toBe(true);
       expect(durationHoursQuestion.validate(0)).toBe(
-        "Duration hours must be between 1 and 12",
+        "Duration hours must be a whole number between 1 and 12",
       );
       expect(durationHoursQuestion.validate(-1)).toBe(
-        "Duration hours must be between 1 and 12",
+        "Duration hours must be a whole number between 1 and 12",
       );
       expect(durationHoursQuestion.validate(13)).toBe(
-        "Duration hours must be between 1 and 12",
+        "Duration hours must be a whole number between 1 and 12",
+      );
+      expect(durationHoursQuestion.validate("1.5")).toBe(
+        "Duration hours must be a whole number between 1 and 12",
+      );
+      expect(durationHoursQuestion.validate("1e1")).toBe(
+        "Duration hours must be a whole number between 1 and 12",
       );
     });
 
@@ -441,7 +447,7 @@ describe("configureProfileAsync", () => {
         (q: unknown) => (q as { name: string }).name === "defaultDurationHours",
       ) as { default: string | number };
 
-      expect(durationHoursQuestion.default).toBe("8");
+      expect(durationHoursQuestion.default).toBe(8);
     });
 
     it("should default defaultDurationHours to 1 when no profile exists", async () => {

--- a/src/configureProfileAsync.ts
+++ b/src/configureProfileAsync.ts
@@ -1,5 +1,11 @@
 import inquirer from "inquirer";
+import { CLIError } from "./CLIError";
 import { awsConfig } from "./awsConfig";
+import {
+  parseSessionDurationHours,
+  sessionDurationHoursValidationMessage,
+  validateSessionDurationHours,
+} from "./sessionDuration";
 
 export async function configureProfileAsync(
   profileName: string,
@@ -54,12 +60,9 @@ export async function configureProfileAsync(
       type: "input" as const,
       name: "defaultDurationHours",
       message: "Default Session Duration Hours (up to 12):",
-      default: (profile && profile.azure_default_duration_hours) || 1,
-      validate: (input: string): boolean | string => {
-        const num = Number(input);
-        if (num > 0 && num <= 12) return true;
-        return "Duration hours must be between 1 and 12";
-      },
+      default:
+        parseSessionDurationHours(profile?.azure_default_duration_hours) ?? 1,
+      validate: validateSessionDurationHours,
     },
     {
       type: "input" as const,
@@ -70,13 +73,20 @@ export async function configureProfileAsync(
   ];
 
   const answers = await inquirer.prompt(questions);
+  const defaultDurationHours = parseSessionDurationHours(
+    answers.defaultDurationHours as string | number | undefined,
+  );
+
+  if (defaultDurationHours === null) {
+    throw new CLIError(sessionDurationHoursValidationMessage);
+  }
 
   await awsConfig.setProfileConfigValuesAsync(profileName, {
     azure_tenant_id: answers.tenantId as string,
     azure_app_id_uri: answers.appIdUri as string,
     azure_default_username: answers.username as string,
     azure_default_role_arn: answers.defaultRoleArn as string,
-    azure_default_duration_hours: answers.defaultDurationHours as string,
+    azure_default_duration_hours: String(defaultDurationHours),
     azure_default_remember_me: (answers.rememberMe as string) === "true",
     region: answers.region as string,
   });

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -590,6 +590,42 @@ describe("login", () => {
       expect(result.durationHours).toBe(1);
     });
 
+    it("should default duration to 1 hour when defaultDurationHours is fractional", async () => {
+      const roles = [
+        {
+          roleArn: "arn:aws:iam::123456789012:role/OnlyRole",
+          principalArn: "arn:aws:iam::123456789012:saml-provider/Provider",
+        },
+      ];
+
+      const result = await login._askUserForRoleAndDurationAsync(
+        roles,
+        true,
+        "",
+        "1.5",
+      );
+
+      expect(result.durationHours).toBe(1);
+    });
+
+    it("should default duration to 1 hour when defaultDurationHours uses scientific notation", async () => {
+      const roles = [
+        {
+          roleArn: "arn:aws:iam::123456789012:role/OnlyRole",
+          principalArn: "arn:aws:iam::123456789012:saml-provider/Provider",
+        },
+      ];
+
+      const result = await login._askUserForRoleAndDurationAsync(
+        roles,
+        true,
+        "",
+        "1e1",
+      );
+
+      expect(result.durationHours).toBe(1);
+    });
+
     it("should throw Error when inquirer returns unknown role", async () => {
       const roles = [
         {
@@ -614,6 +650,26 @@ describe("login", () => {
 
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toBe("Unable to find role");
+    });
+
+    it("should throw CLIError when prompted durationHours is not a whole number", async () => {
+      const roles = [
+        {
+          roleArn: "arn:aws:iam::123456789012:role/OnlyRole",
+          principalArn: "arn:aws:iam::123456789012:saml-provider/Provider",
+        },
+      ];
+
+      vi.mocked(inquirer.prompt).mockResolvedValue({ durationHours: "1.5" });
+
+      const error = await login
+        ._askUserForRoleAndDurationAsync(roles, false, "", "")
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(CLIError);
+      expect((error as CLIError).message).toBe(
+        "Duration hours must be a whole number between 1 and 12",
+      );
     });
   });
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -15,6 +15,11 @@ import fs from "fs/promises";
 import { Agent } from "https";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { states } from "./loginStates";
+import {
+  parseSessionDurationHours,
+  sessionDurationHoursValidationMessage,
+  validateSessionDurationHours,
+} from "./sessionDuration";
 
 const debug = _debug("az2aws");
 
@@ -633,17 +638,7 @@ export const login = {
     durationHours: number;
   }> {
     let role;
-    let durationHours = 1;
-    if (defaultDurationHours) {
-      const parsedDuration = parseInt(defaultDurationHours, 10);
-      if (
-        !Number.isNaN(parsedDuration) &&
-        parsedDuration > 0 &&
-        parsedDuration <= 12
-      ) {
-        durationHours = parsedDuration;
-      }
-    }
+    let durationHours = parseSessionDurationHours(defaultDurationHours) ?? 1;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const questions: any[] = [];
     if (roles.length === 0) {
@@ -689,12 +684,8 @@ export const login = {
         name: "durationHours",
         message: "Session Duration Hours (up to 12):",
         type: "input",
-        default: defaultDurationHours || 1,
-        validate: (input: string): boolean | string => {
-          const num = Number(input);
-          if (num > 0 && num <= 12) return true;
-          return "Duration hours must be between 1 and 12";
-        },
+        default: durationHours,
+        validate: validateSessionDurationHours,
       });
     }
 
@@ -704,7 +695,13 @@ export const login = {
       const answers = await inquirer.prompt(questions);
       if (!role) role = roles.find((r) => r.roleArn === answers.role);
       if (answers.durationHours) {
-        durationHours = parseInt(answers.durationHours as string, 10);
+        const parsedDurationHours = parseSessionDurationHours(
+          answers.durationHours as string | number | undefined,
+        );
+        if (parsedDurationHours === null) {
+          throw new CLIError(sessionDurationHoursValidationMessage);
+        }
+        durationHours = parsedDurationHours;
       }
     }
 

--- a/src/sessionDuration.test.ts
+++ b/src/sessionDuration.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSessionDurationHours,
+  sessionDurationHoursValidationMessage,
+  validateSessionDurationHours,
+} from "./sessionDuration";
+
+describe("sessionDuration", () => {
+  describe("parseSessionDurationHours", () => {
+    it("should accept whole numbers between 1 and 12", () => {
+      expect(parseSessionDurationHours("1")).toBe(1);
+      expect(parseSessionDurationHours("12")).toBe(12);
+      expect(parseSessionDurationHours(8)).toBe(8);
+      expect(parseSessionDurationHours("08")).toBe(8);
+    });
+
+    it("should reject fractional and scientific notation values", () => {
+      expect(parseSessionDurationHours("1.5")).toBeNull();
+      expect(parseSessionDurationHours("1e1")).toBeNull();
+      expect(parseSessionDurationHours(1.5)).toBeNull();
+    });
+
+    it("should reject non-positive, too large, and non-numeric values", () => {
+      expect(parseSessionDurationHours("0")).toBeNull();
+      expect(parseSessionDurationHours("-1")).toBeNull();
+      expect(parseSessionDurationHours("13")).toBeNull();
+      expect(parseSessionDurationHours("abc")).toBeNull();
+      expect(parseSessionDurationHours(undefined)).toBeNull();
+    });
+  });
+
+  describe("validateSessionDurationHours", () => {
+    it("should return true for valid values", () => {
+      expect(validateSessionDurationHours("1")).toBe(true);
+      expect(validateSessionDurationHours("12")).toBe(true);
+      expect(validateSessionDurationHours(6)).toBe(true);
+    });
+
+    it("should return the validation message for invalid values", () => {
+      expect(validateSessionDurationHours("1.5")).toBe(
+        sessionDurationHoursValidationMessage,
+      );
+      expect(validateSessionDurationHours("1e1")).toBe(
+        sessionDurationHoursValidationMessage,
+      );
+      expect(validateSessionDurationHours("0")).toBe(
+        sessionDurationHoursValidationMessage,
+      );
+    });
+  });
+});

--- a/src/sessionDuration.ts
+++ b/src/sessionDuration.ts
@@ -1,0 +1,32 @@
+export const sessionDurationHoursValidationMessage =
+  "Duration hours must be a whole number between 1 and 12";
+
+export function parseSessionDurationHours(
+  input: string | number | undefined,
+): number | null {
+  if (input === undefined) {
+    return null;
+  }
+
+  if (typeof input === "number") {
+    return Number.isInteger(input) && input > 0 && input <= 12 ? input : null;
+  }
+
+  const trimmed = input.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  return parsed > 0 && parsed <= 12 ? parsed : null;
+}
+
+export function validateSessionDurationHours(
+  input: string | number,
+): true | string {
+  // Inquirer types `validate` input as string, but it may validate a numeric
+  // `default` value before coercing it to user input.
+  return parseSessionDurationHours(input) === null
+    ? sessionDurationHoursValidationMessage
+    : true;
+}


### PR DESCRIPTION
## Summary
- add shared parsing and validation helpers for session duration hours
- reject fractional and scientific-notation values in configure and login prompts
- cover numeric inquirer defaults and invalid prompt values with focused tests

## Testing
- pnpm vitest run src/sessionDuration.test.ts src/configureProfileAsync.test.ts src/login.test.ts