### PR TITLE
refactor: reduce runtime any usage and lint suppressions

### DIFF
--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -166,7 +166,9 @@ export const awsConfig = {
     return profiles;
   },
 
-  async _loadAsync<T>(type: string): Promise<T | undefined> {
+  async _loadAsync<T extends Record<string, unknown>>(
+    type: string,
+  ): Promise<T | undefined> {
     if (!paths[type]) throw new Error(`Unknown config type: '${type}'`);
 
     return new Promise<T | undefined>((resolve, reject) => {
@@ -182,10 +184,7 @@ export const awsConfig = {
         }
 
         debug("Parsing data");
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const parsedIni: any = ini.parse(data);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        const parsedIni = ini.parse(data) as T;
         return resolve(parsedIni);
       });
     });

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -2867,6 +2867,45 @@ describe("login", () => {
       expect(mockBrowser.close).toHaveBeenCalled();
     });
 
+    it("should tolerate rejected respond promise when SAML response is received", async () => {
+      const mockPage = createMockPage();
+      const mockBrowser = createMockBrowser(mockPage);
+      mockPuppeteerLaunch.mockResolvedValue(mockBrowser);
+
+      const promise = login._performLoginAsync(
+        "https://login.example.com",
+        true,
+        false,
+        false,
+        false,
+        false,
+        "",
+        undefined,
+        false,
+        false,
+        false,
+        false,
+      );
+
+      await mockPage.waitForRequestInterception();
+
+      const requestHandler = mockPage.getRequestHandler();
+      if (requestHandler) {
+        requestHandler({
+          url: () => "https://signin.aws.amazon.com/saml",
+          postData: () => "SAMLResponse=validBase64EncodedSaml",
+          respond: vi.fn().mockRejectedValue(new Error("request closed")),
+          continue: vi.fn().mockResolvedValue(undefined),
+        });
+      }
+
+      await Promise.resolve();
+
+      const result = await promise;
+      expect(result).toBe("validBase64EncodedSaml");
+      expect(mockBrowser.close).toHaveBeenCalled();
+    });
+
     it("should close browser when puppeteer launch succeeds but SAML response is missing", async () => {
       const mockPage = createMockPage();
       const mockBrowser = createMockBrowser(mockPage);
@@ -3201,6 +3240,55 @@ describe("login", () => {
       expect(continueMocks[0]).toHaveBeenCalled();
       expect(continueMocks[1]).toHaveBeenCalled();
       expect(continueMocks[2]).toHaveBeenCalled();
+    });
+
+    it("should tolerate rejected continue promise before a later SAML response", async () => {
+      const mockPage = createMockPage();
+      const mockBrowser = createMockBrowser(mockPage);
+      mockPuppeteerLaunch.mockResolvedValue(mockBrowser);
+
+      const continueMock = vi
+        .fn()
+        .mockRejectedValue(new Error("request already handled"));
+
+      const promise = login._performLoginAsync(
+        "https://login.example.com",
+        true,
+        false,
+        false,
+        false,
+        false,
+        "",
+        undefined,
+        false,
+        false,
+        false,
+        false,
+      );
+
+      await mockPage.waitForRequestInterception();
+
+      const requestHandler = mockPage.getRequestHandler();
+      if (requestHandler) {
+        requestHandler({
+          url: () => "https://login.microsoftonline.com/common/oauth2",
+          postData: () => undefined,
+          respond: vi.fn().mockResolvedValue(undefined),
+          continue: continueMock,
+        });
+        requestHandler({
+          url: () => "https://signin.aws.amazon.com/saml",
+          postData: () => "SAMLResponse=validSamlResponse",
+          respond: vi.fn().mockResolvedValue(undefined),
+          continue: vi.fn().mockResolvedValue(undefined),
+        });
+      }
+
+      await Promise.resolve();
+
+      const result = await promise;
+      expect(result).toBe("validSamlResponse");
+      expect(continueMock).toHaveBeenCalled();
     });
 
     it("should handle GovCloud SAML endpoint correctly", async () => {

--- a/src/login.ts
+++ b/src/login.ts
@@ -63,6 +63,16 @@ type RoleDurationAnswers = {
   durationHours?: string | number;
 };
 
+function handleBackgroundPromise(
+  promise: Promise<unknown>,
+  description: string,
+): void {
+  void promise.catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    debug(`${description}: ${message}`);
+  });
+}
+
 export const login = {
   async _createHttpsProxyAgentAsync(
     proxyUrl: string,
@@ -488,19 +498,28 @@ export const login = {
           ) {
             resolve(undefined);
             samlResponseData = req.postData();
-            void req.respond({
-              status: 200,
-              contentType: "text/plain",
-              headers: {},
-              body: "",
-            });
+            handleBackgroundPromise(
+              req.respond({
+                status: 200,
+                contentType: "text/plain",
+                headers: {},
+                body: "",
+              }),
+              `Failed to respond to intercepted request ${reqURL}`,
+            );
             if (browser) {
-              void browser.close();
+              handleBackgroundPromise(
+                browser.close(),
+                "Failed to close browser after receiving SAML response",
+              );
             }
             browser = undefined;
             debug(`Received SAML response, browser closed`);
           } else {
-            void req.continue();
+            handleBackgroundPromise(
+              req.continue(),
+              `Failed to continue intercepted request ${reqURL}`,
+            );
           }
         });
       });

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,6 +1,6 @@
 import { setTimeout } from "node:timers/promises";
 import crypto from "node:crypto";
-import inquirer from "inquirer";
+import inquirer, { type DistinctQuestion } from "inquirer";
 import zlib from "zlib";
 import { STS, STSClientConfig } from "@aws-sdk/client-sts";
 import { load } from "cheerio";
@@ -58,6 +58,10 @@ interface Role {
 }
 
 type AwsCredentials = ProfileCredentials;
+type RoleDurationAnswers = {
+  role?: string;
+  durationHours?: string | number;
+};
 
 export const login = {
   async _createHttpsProxyAgentAsync(
@@ -484,22 +488,19 @@ export const login = {
           ) {
             resolve(undefined);
             samlResponseData = req.postData();
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            req.respond({
+            void req.respond({
               status: 200,
               contentType: "text/plain",
               headers: {},
               body: "",
             });
             if (browser) {
-              // eslint-disable-next-line @typescript-eslint/no-floating-promises
-              browser.close();
+              void browser.close();
             }
             browser = undefined;
             debug(`Received SAML response, browser closed`);
           } else {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            req.continue();
+            void req.continue();
           }
         });
       });
@@ -525,8 +526,7 @@ export const login = {
 
       if (cliProxy) {
         let totalUnrecognizedDelay = 0;
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
+        for (;;) {
           if (samlResponseData) break;
 
           let foundState = false;
@@ -629,25 +629,22 @@ export const login = {
     const saml = load(samlText, { xmlMode: true });
 
     debug("Looking for role SAML attribute");
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const roles: Role[] = saml(
+    const roleSelection = saml(
       "Attribute[Name='https://aws.amazon.com/SAML/Attributes/Role']>AttributeValue",
-    )
-      .map(function () {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        const roleAndPrincipal = saml(this).text();
-        const parts = roleAndPrincipal.split(",");
+    );
+    const roleNodes = roleSelection.toArray();
+    const roles = roleNodes.map((roleNode) => {
+      const roleAndPrincipal = saml(roleNode).text();
+      const parts = roleAndPrincipal.split(",");
 
-        // Role / Principal claims may be in either order
-        const [roleIdx, principalIdx] = parts[0].includes(":role/")
-          ? [0, 1]
-          : [1, 0];
-        const roleArn = parts[roleIdx].trim();
-        const principalArn = parts[principalIdx].trim();
-        return { roleArn, principalArn };
-      })
-      .get();
+      // Role / Principal claims may be in either order
+      const [roleIdx, principalIdx] = parts[0].includes(":role/")
+        ? [0, 1]
+        : [1, 0];
+      const roleArn = parts[roleIdx].trim();
+      const principalArn = parts[principalIdx].trim();
+      return { roleArn, principalArn };
+    });
     debug("Found roles", roles);
     return roles;
   },
@@ -673,10 +670,9 @@ export const login = {
     role: Role;
     durationHours: number;
   }> {
-    let role;
+    let role: Role | undefined;
     let durationHours = parseSessionDurationHours(defaultDurationHours) ?? 1;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const questions: any[] = [];
+    const questions: DistinctQuestion<RoleDurationAnswers>[] = [];
     if (roles.length === 0) {
       throw new CLIError("No roles found in SAML response.");
     } else if (roles.length === 1) {
@@ -720,7 +716,7 @@ export const login = {
         name: "durationHours",
         message: "Session Duration Hours (up to 12):",
         type: "input",
-        default: durationHours,
+        default: String(durationHours),
         validate: validateSessionDurationHours,
       });
     }
@@ -728,11 +724,13 @@ export const login = {
     // Don't prompt for questions if not needed, an unneeded TTYWRAP prevents node from exiting when
     // user is logged in and using multiple profiles --all-profiles and --no-prompt
     if (questions.length > 0) {
-      const answers = await inquirer.prompt(questions);
-      if (!role) role = roles.find((r) => r.roleArn === answers.role);
+      const answers = await inquirer.prompt<RoleDurationAnswers>(questions);
+      if (!role && answers.role) {
+        role = roles.find((r) => r.roleArn === answers.role);
+      }
       if (answers.durationHours) {
         const parsedDurationHours = parseSessionDurationHours(
-          answers.durationHours as string | number | undefined,
+          answers.durationHours,
         );
         if (parsedDurationHours === null) {
           throw new CLIError(sessionDurationHoursValidationMessage);

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -1,6 +1,6 @@
 import { setTimeout } from "node:timers/promises";
 import inquirer from "inquirer";
-import { Page, ElementHandle } from "puppeteer";
+import type { ElementHandle, Page } from "puppeteer";
 import _debug from "debug";
 import { CLIError } from "./CLIError";
 
@@ -19,6 +19,22 @@ export interface State {
   name: string;
   selector: string;
   handler: StateHandler;
+}
+
+type AccountChoice = {
+  message: string;
+  selector: string;
+};
+
+async function readTextContent<T extends Node>(
+  page: Page,
+  element: ElementHandle<T> | null,
+): Promise<string> {
+  if (!element) {
+    return "";
+  }
+
+  return page.evaluate((node) => node.textContent ?? "", element);
 }
 
 /**
@@ -41,24 +57,18 @@ export const states: State[] = [
       const error = await page.$(".alert-error");
       if (error) {
         debug("Found error message. Displaying");
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const errorMessage = await page.evaluate(
-          // eslint-disable-next-line
-          (err) => err?.textContent ?? "",
-          error,
-        );
+        const errorMessage = await readTextContent(page, error);
         console.log(errorMessage);
       }
 
-      let username;
+      let username: string;
 
       if (noPrompt && defaultUsername) {
         debug("Not prompting user for username");
         username = defaultUsername;
       } else {
         debug("Prompting user for username");
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        ({ username } = await inquirer.prompt([
+        ({ username } = await inquirer.prompt<{ username: string }>([
           {
             type: "input" as const,
             name: "username",
@@ -84,7 +94,6 @@ export const states: State[] = [
       await page.keyboard.press("Backspace");
 
       debug("Typing username");
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       await page.keyboard.type(username);
 
       await setTimeout(500);
@@ -122,27 +131,17 @@ export const states: State[] = [
     async handler(page: Page): Promise<void> {
       debug("Multiple accounts associated with username.");
       const aadTile = await page.$("#aadTileTitle");
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const aadTileMessage: string = await page.evaluate(
-        // eslint-disable-next-line
-        (a) => a?.textContent ?? "",
-        aadTile,
-      );
+      const aadTileMessage = await readTextContent(page, aadTile);
 
       const msaTile = await page.$("#msaTileTitle");
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const msaTileMessage: string = await page.evaluate(
-        // eslint-disable-next-line
-        (m) => m?.textContent ?? "",
-        msaTile,
-      );
+      const msaTileMessage = await readTextContent(page, msaTile);
 
-      const accounts = [
+      const accounts: AccountChoice[] = [
         aadTile ? { message: aadTileMessage, selector: "#aadTileTitle" } : null,
         msaTile ? { message: msaTileMessage, selector: "#msaTileTitle" } : null,
-      ].filter((a): a is { message: string; selector: string } => a !== null);
+      ].filter((account): account is AccountChoice => account !== null);
 
-      let account;
+      let account: AccountChoice | undefined;
       if (accounts.length === 0) {
         throw new CLIError("No accounts found on account selection screen.");
       } else if (accounts.length === 1) {
@@ -152,7 +151,9 @@ export const states: State[] = [
         console.log(
           "It looks like this Username is used with more than one account from Microsoft. Which one do you want to use?",
         );
-        const answers = await inquirer.prompt([
+        const { account: selectedAccount } = await inquirer.prompt<{
+          account: string;
+        }>([
           {
             name: "account",
             message: "Account:",
@@ -162,7 +163,9 @@ export const states: State[] = [
           },
         ]);
 
-        account = accounts.find((a) => a.message === answers.account);
+        account = accounts.find((candidate) => {
+          return candidate.message === selectedAccount;
+        });
       }
 
       if (!account) {
@@ -179,35 +182,21 @@ export const states: State[] = [
     selector: `input[value='Send notification']`,
     async handler(page: Page) {
       debug("Sending notification");
-      // eslint-disable-next-line
       await page.click("input[value='Send notification']");
       debug("Waiting for auth code");
-      // eslint-disable-next-line
       await page.waitForSelector(`#idRemoteNGC_DisplaySign`, {
         visible: true,
         timeout: 60000,
       });
       debug("Printing the message displayed");
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const messageElement = await page.$(
         "#idDiv_RemoteNGC_PollingDescription",
       );
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const codeElement = await page.$("#idRemoteNGC_DisplaySign");
-      // eslint-disable-next-line
-      const message = await page.evaluate(
-        // eslint-disable-next-line
-        (el) => el?.textContent ?? "",
-        messageElement,
-      );
+      const message = await readTextContent(page, messageElement);
       console.log(message);
       debug("Printing the auth code");
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const authCode = await page.evaluate(
-        // eslint-disable-next-line
-        (el) => el?.textContent ?? "",
-        codeElement,
-      );
+      const authCode = await readTextContent(page, codeElement);
       console.log(authCode);
       debug("Waiting for response");
       await page.waitForSelector(`#idRemoteNGC_DisplaySign`, {
@@ -229,25 +218,19 @@ export const states: State[] = [
       const error = await page.$(".alert-error");
       if (error) {
         debug("Found error message. Displaying");
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const errorMessage = await page.evaluate(
-          // eslint-disable-next-line
-          (err) => err?.textContent ?? "",
-          error,
-        );
+        const errorMessage = await readTextContent(page, error);
         console.log(errorMessage);
         defaultPassword = ""; // Password error. Unset the default and allow user to enter it.
       }
 
-      let password;
+      let password: string;
 
       if (noPrompt && defaultPassword) {
         debug("Not prompting user for password");
         password = defaultPassword;
       } else {
         debug("Prompting user for password");
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        ({ password } = await inquirer.prompt([
+        ({ password } = await inquirer.prompt<{ password: string }>([
           {
             name: "password",
             message: "Password:",
@@ -260,7 +243,6 @@ export const states: State[] = [
       await page.focus(`input[name="Password"],input[name="passwd"]`);
 
       debug("Typing password");
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       await page.keyboard.type(password);
 
       debug("Submitting form");
@@ -274,11 +256,7 @@ export const states: State[] = [
     name: "TFA instructions",
     selector: `#idDiv_SAOTCAS_Description`,
     async handler(page: Page, selected: ElementHandle): Promise<void> {
-      const descriptionMessage = await page.evaluate(
-        // eslint-disable-next-line
-        (description) => description?.textContent ?? "",
-        selected,
-      );
+      const descriptionMessage = await readTextContent(page, selected);
       console.log(descriptionMessage);
 
       try {
@@ -292,10 +270,8 @@ export const states: State[] = [
           "#idRichContext_DisplaySign",
         );
         debug("Reading the authentication code");
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const authenticationCode = await page.evaluate(
-          // eslint-disable-next-line
-          (d) => d?.textContent ?? "",
+        const authenticationCode = await readTextContent(
+          page,
           authenticationCodeElement,
         );
         debug("Printing the authentication code to console");
@@ -315,12 +291,7 @@ export const states: State[] = [
     name: "TFA failed",
     selector: `#idDiv_SAASDS_Description,#idDiv_SAASTO_Description`,
     async handler(page: Page, selected: ElementHandle): Promise<void> {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const descriptionMessage = await page.evaluate(
-        // eslint-disable-next-line
-        (description) => description?.textContent ?? "",
-        selected,
-      );
+      const descriptionMessage = await readTextContent(page, selected);
       throw new CLIError(descriptionMessage);
     },
   },
@@ -331,26 +302,17 @@ export const states: State[] = [
       const error = await page.$(".alert-error");
       if (error) {
         debug("Found error message. Displaying");
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const errorMessage = await page.evaluate(
-          // eslint-disable-next-line
-          (err) => err?.textContent ?? "",
-          error,
-        );
+        const errorMessage = await readTextContent(page, error);
         console.log(errorMessage);
       } else {
         const description = await page.$("#idDiv_SAOTCC_Description");
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const descriptionMessage = await page.evaluate(
-          // eslint-disable-next-line
-          (d) => d?.textContent ?? "",
-          description,
-        );
+        const descriptionMessage = await readTextContent(page, description);
         console.log(descriptionMessage);
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const { verificationCode } = await inquirer.prompt([
+      const { verificationCode } = await inquirer.prompt<{
+        verificationCode: string;
+      }>([
         {
           type: "input" as const,
           name: "verificationCode",
@@ -368,7 +330,6 @@ export const states: State[] = [
       await page.keyboard.press("Backspace");
 
       debug("Typing verification code");
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       await page.keyboard.type(verificationCode);
 
       debug("Submitting form");
@@ -417,12 +378,7 @@ export const states: State[] = [
     name: "Service exception",
     selector: "#service_exception_message",
     async handler(page: Page, selected: ElementHandle): Promise<void> {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const descriptionMessage = await page.evaluate(
-        // eslint-disable-next-line
-        (description) => description?.textContent ?? "",
-        selected,
-      );
+      const descriptionMessage = await readTextContent(page, selected);
       throw new CLIError(descriptionMessage);
     },
   },


### PR DESCRIPTION
## Summary
- reduce runtime any usage in config and login flows by tightening generic and prompt types
- replace repeated textContent reads with a typed helper in loginStates
- remove runtime lint suppressions by using void for intentional fire-and-forget calls and typed role parsing

## Testing
- pnpm build
- pnpm eslint
- pnpm test

Closes #84