### PR TITLE
fix: clear password input before typing to prevent appending

### DIFF
--- a/src/loginStates.test.ts
+++ b/src/loginStates.test.ts
@@ -295,8 +295,7 @@ describe("loginStates", () => {
         return Promise.resolve();
       });
 
-      const passwordSelector =
-        'input[name="Password"]:not(.moveOffScreen),input[name="passwd"]:not(.moveOffScreen)';
+      const { selector } = getPasswordState();
 
       await getPasswordState().handler(
         mockPage as never,
@@ -308,11 +307,11 @@ describe("loginStates", () => {
       );
 
       // Should focus on password input with :not(.moveOffScreen) filter
-      expect(mockPage.focus).toHaveBeenCalledWith(passwordSelector);
+      expect(mockPage.focus).toHaveBeenCalledWith(selector);
 
       // Should select all text and delete with single backspace
       expect(mockPage.$eval).toHaveBeenCalledWith(
-        passwordSelector,
+        selector,
         expect.any(Function),
       );
       expect(mockPage.keyboard.press).toHaveBeenCalledWith("Backspace");

--- a/src/loginStates.test.ts
+++ b/src/loginStates.test.ts
@@ -297,6 +297,9 @@ describe("loginStates", () => {
 
       const { selector } = getPasswordState();
 
+      // Guard: selector must exclude hidden inputs to avoid operating on the wrong element
+      expect(selector).toContain(":not(.moveOffScreen)");
+
       await getPasswordState().handler(
         mockPage as never,
         createMockElementHandle() as never,
@@ -306,10 +309,8 @@ describe("loginStates", () => {
         false,
       );
 
-      // Should focus on password input with :not(.moveOffScreen) filter
+      // Handler must use the same selector as the state for both focus and clear
       expect(mockPage.focus).toHaveBeenCalledWith(selector);
-
-      // Should select all text and delete with single backspace
       expect(mockPage.$eval).toHaveBeenCalledWith(
         selector,
         expect.any(Function),

--- a/src/loginStates.test.ts
+++ b/src/loginStates.test.ts
@@ -273,9 +273,30 @@ describe("loginStates", () => {
       expect(mockPage.keyboard.type).toHaveBeenCalledWith("promptedPassword");
     });
 
-    it("should focus, type password, and submit form", async () => {
+    it("should focus, clear input, type password, and submit form", async () => {
       const mockPage = createMockPage();
       mockPage.$.mockResolvedValue(null);
+
+      const callOrder: string[] = [];
+      mockPage.focus.mockImplementation(() => {
+        callOrder.push("focus");
+        return Promise.resolve();
+      });
+      mockPage.$eval.mockImplementation(() => {
+        callOrder.push("$eval");
+        return Promise.resolve();
+      });
+      mockPage.keyboard.press.mockImplementation(() => {
+        callOrder.push("press");
+        return Promise.resolve();
+      });
+      mockPage.keyboard.type.mockImplementation(() => {
+        callOrder.push("type");
+        return Promise.resolve();
+      });
+
+      const passwordSelector =
+        'input[name="Password"]:not(.moveOffScreen),input[name="passwd"]:not(.moveOffScreen)';
 
       await getPasswordState().handler(
         mockPage as never,
@@ -286,10 +307,15 @@ describe("loginStates", () => {
         false,
       );
 
-      // Should focus on password input
-      expect(mockPage.focus).toHaveBeenCalledWith(
-        'input[name="Password"],input[name="passwd"]',
+      // Should focus on password input with :not(.moveOffScreen) filter
+      expect(mockPage.focus).toHaveBeenCalledWith(passwordSelector);
+
+      // Should select all text and delete with single backspace
+      expect(mockPage.$eval).toHaveBeenCalledWith(
+        passwordSelector,
+        expect.any(Function),
       );
+      expect(mockPage.keyboard.press).toHaveBeenCalledWith("Backspace");
 
       // Should type password
       expect(mockPage.keyboard.type).toHaveBeenCalledWith("testPassword");
@@ -298,6 +324,9 @@ describe("loginStates", () => {
       expect(mockPage.click).toHaveBeenCalledWith(
         "span[class=submit],input[type=submit]",
       );
+
+      // Verify clear happens before type (regression for #166)
+      expect(callOrder).toEqual(["focus", "$eval", "press", "type"]);
     });
   });
 

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -259,6 +259,12 @@ export const states: State[] = [
       debug("Focusing on password input");
       await page.focus(`input[name="Password"],input[name="passwd"]`);
 
+      debug("Clearing input");
+      await page.$eval('input[name="Password"],input[name="passwd"]', (el) => {
+        el.select();
+      });
+      await page.keyboard.press("Backspace");
+
       debug("Typing password");
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       await page.keyboard.type(password);

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -256,11 +256,14 @@ export const states: State[] = [
         ]));
       }
 
+      const passwordSelector =
+        'input[name="Password"]:not(.moveOffScreen),input[name="passwd"]:not(.moveOffScreen)';
+
       debug("Focusing on password input");
-      await page.focus(`input[name="Password"],input[name="passwd"]`);
+      await page.focus(passwordSelector);
 
       debug("Clearing input");
-      await page.$eval('input[name="Password"],input[name="passwd"]', (el) => {
+      await page.$eval(passwordSelector, (el) => {
         el.select();
       });
       await page.keyboard.press("Backspace");

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -21,6 +21,9 @@ export interface State {
   handler: StateHandler;
 }
 
+const PASSWORD_SELECTOR =
+  'input[name="Password"]:not(.moveOffScreen),input[name="passwd"]:not(.moveOffScreen)';
+
 /**
  * To proxy the input/output of the Azure login page, it's easiest to run a loop that
  * monitors the state of the page and then perform the corresponding CLI behavior.
@@ -218,7 +221,7 @@ export const states: State[] = [
   },
   {
     name: "password input",
-    selector: `input[name="Password"]:not(.moveOffScreen),input[name="passwd"]:not(.moveOffScreen)`,
+    selector: PASSWORD_SELECTOR,
     async handler(
       page: Page,
       _selected: ElementHandle,
@@ -256,14 +259,11 @@ export const states: State[] = [
         ]));
       }
 
-      const passwordSelector =
-        'input[name="Password"]:not(.moveOffScreen),input[name="passwd"]:not(.moveOffScreen)';
-
       debug("Focusing on password input");
-      await page.focus(passwordSelector);
+      await page.focus(PASSWORD_SELECTOR);
 
       debug("Clearing input");
-      await page.$eval(passwordSelector, (el) => {
+      await page.$eval(PASSWORD_SELECTOR, (el) => {
         el.select();
       });
       await page.keyboard.press("Backspace");


### PR DESCRIPTION
## Summary
- Password handler was missing the `select() → Backspace` clear step that username and TFA handlers already use
- This caused the new password to be appended to existing input (e.g., from browser autofill or a previous failed attempt)
- Applied the same focus → select → delete → type pattern used by the other handlers

Closes #166

## Test plan
- [ ] Verify password field is cleared before typing when browser autofill pre-populates the field
- [ ] Verify retry after incorrect password does not append the new password to the old one
- [ ] Verify normal password entry still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)