### PR TITLE
fix: support custom AWS config parent directories

### DIFF
--- a/src/awsConfig.test.ts
+++ b/src/awsConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 import { chmod, mkdir } from "node:fs/promises";
+import os from "os";
 import path from "path";
 import { awsConfig } from "./awsConfig";
 import { paths } from "./paths";
@@ -13,6 +14,7 @@ vi.mock("node:fs/promises", () => ({
 
 const defaultConfigPath = paths.config;
 const defaultCredentialsPath = paths.credentials;
+const tempDir = os.tmpdir();
 
 describe("awsConfig", () => {
   beforeEach(() => {
@@ -573,7 +575,7 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
     });
 
     it("should harden custom directories that are newly created", async () => {
-      const customConfigDir = path.join("/tmp", "custom-aws");
+      const customConfigDir = path.join(tempDir, "custom-aws");
       const nestedCustomConfigDir = path.join(customConfigDir, "nested");
       const customConfigPath = path.join(nestedCustomConfigDir, "config");
       paths.config = customConfigPath;
@@ -609,7 +611,7 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
 
     it("should not harden existing custom parent directories", async () => {
       const customCredentialsPath = path.join(
-        "/tmp",
+        tempDir,
         "custom-aws",
         "credentials",
       );

--- a/src/awsConfig.test.ts
+++ b/src/awsConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 import { chmod, mkdir } from "node:fs/promises";
+import path from "path";
 import { awsConfig } from "./awsConfig";
 import { paths } from "./paths";
 
@@ -10,9 +11,14 @@ vi.mock("node:fs/promises", () => ({
   chmod: vi.fn().mockResolvedValue(undefined),
 }));
 
+const defaultConfigPath = paths.config;
+const defaultCredentialsPath = paths.credentials;
+
 describe("awsConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    paths.config = defaultConfigPath;
+    paths.credentials = defaultCredentialsPath;
   });
 
   describe("getProfileConfigAsync", () => {
@@ -554,12 +560,92 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
       ).resolves.toBeUndefined();
 
       expect(fs.writeFile).toHaveBeenCalled();
-      expect(mkdir).toHaveBeenCalledWith(paths.awsDir, {
+      expect(mkdir).toHaveBeenCalledWith(path.dirname(paths.config), {
         recursive: true,
         mode: 0o700,
       });
-      expect(chmod).toHaveBeenNthCalledWith(1, paths.awsDir, 0o700);
+      expect(chmod).toHaveBeenNthCalledWith(
+        1,
+        path.dirname(paths.config),
+        0o700,
+      );
       expect(chmod).toHaveBeenNthCalledWith(2, paths.config, 0o600);
+    });
+
+    it("should create the parent directory for a custom config path", async () => {
+      const customConfigPath = path.join("/tmp", "custom-aws", "config");
+      paths.config = customConfigPath;
+
+      vi.mocked(fs.writeFile).mockImplementation(
+        (
+          _path: fs.PathOrFileDescriptor,
+          _data: string | NodeJS.ArrayBufferView,
+          callback: fs.NoParamCallback,
+        ) => {
+          callback(null);
+        },
+      );
+
+      await expect(
+        awsConfig._saveAsync("config", {
+          default: {
+            azure_tenant_id: "test-tenant",
+            azure_app_id_uri: "https://app.example.com",
+          } as never,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(mkdir).toHaveBeenCalledWith(path.dirname(customConfigPath), {
+        recursive: true,
+        mode: 0o700,
+      });
+      expect(chmod).toHaveBeenNthCalledWith(
+        1,
+        path.dirname(customConfigPath),
+        0o700,
+      );
+      expect(chmod).toHaveBeenNthCalledWith(2, customConfigPath, 0o600);
+    });
+
+    it("should create the parent directory for a custom credentials path", async () => {
+      const customCredentialsPath = path.join(
+        "/tmp",
+        "custom-aws",
+        "credentials",
+      );
+      paths.credentials = customCredentialsPath;
+
+      vi.mocked(fs.writeFile).mockImplementation(
+        (
+          _path: fs.PathOrFileDescriptor,
+          _data: string | NodeJS.ArrayBufferView,
+          callback: fs.NoParamCallback,
+        ) => {
+          callback(null);
+        },
+      );
+
+      await expect(
+        awsConfig._saveAsync("credentials", {
+          default: {
+            aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+            aws_secret_access_key: "secret",
+            aws_session_token: "token",
+            aws_expiration: "2024-12-31T23:59:59.000Z",
+          },
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(mkdir).toHaveBeenCalledWith(path.dirname(customCredentialsPath), {
+        recursive: true,
+        mode: 0o700,
+      });
+      expect(chmod).toHaveBeenNthCalledWith(
+        1,
+        path.dirname(customCredentialsPath),
+        0o700,
+      );
+      expect(chmod).toHaveBeenNthCalledWith(2, customCredentialsPath, 0o600);
     });
 
     it("should ignore permission-related chmod errors", async () => {

--- a/src/awsConfig.test.ts
+++ b/src/awsConfig.test.ts
@@ -648,6 +648,33 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
       expect(chmod).toHaveBeenNthCalledWith(2, customCredentialsPath, 0o600);
     });
 
+    it("should not harden the current working directory for relative target paths", async () => {
+      paths.config = "config";
+
+      vi.mocked(fs.writeFile).mockImplementation(
+        (
+          _path: fs.PathOrFileDescriptor,
+          _data: string | NodeJS.ArrayBufferView,
+          callback: fs.NoParamCallback,
+        ) => {
+          callback(null);
+        },
+      );
+
+      await expect(
+        awsConfig._saveAsync("config", {
+          default: {
+            azure_tenant_id: "test-tenant",
+            azure_app_id_uri: "https://app.example.com",
+          } as never,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(mkdir).not.toHaveBeenCalled();
+      expect(chmod).toHaveBeenCalledTimes(1);
+      expect(chmod).toHaveBeenCalledWith("config", 0o600);
+    });
+
     it("should ignore permission-related chmod errors", async () => {
       vi.mocked(fs.writeFile).mockImplementation(
         (

--- a/src/awsConfig.test.ts
+++ b/src/awsConfig.test.ts
@@ -572,9 +572,12 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
       expect(chmod).toHaveBeenNthCalledWith(2, paths.config, 0o600);
     });
 
-    it("should create the parent directory for a custom config path", async () => {
-      const customConfigPath = path.join("/tmp", "custom-aws", "config");
+    it("should harden custom directories that are newly created", async () => {
+      const customConfigDir = path.join("/tmp", "custom-aws");
+      const nestedCustomConfigDir = path.join(customConfigDir, "nested");
+      const customConfigPath = path.join(nestedCustomConfigDir, "config");
       paths.config = customConfigPath;
+      vi.mocked(mkdir).mockResolvedValueOnce(customConfigDir);
 
       vi.mocked(fs.writeFile).mockImplementation(
         (
@@ -595,19 +598,16 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
         }),
       ).resolves.toBeUndefined();
 
-      expect(mkdir).toHaveBeenCalledWith(path.dirname(customConfigPath), {
+      expect(mkdir).toHaveBeenCalledWith(nestedCustomConfigDir, {
         recursive: true,
         mode: 0o700,
       });
-      expect(chmod).toHaveBeenNthCalledWith(
-        1,
-        path.dirname(customConfigPath),
-        0o700,
-      );
-      expect(chmod).toHaveBeenNthCalledWith(2, customConfigPath, 0o600);
+      expect(chmod).toHaveBeenNthCalledWith(1, customConfigDir, 0o700);
+      expect(chmod).toHaveBeenNthCalledWith(2, nestedCustomConfigDir, 0o700);
+      expect(chmod).toHaveBeenNthCalledWith(3, customConfigPath, 0o600);
     });
 
-    it("should create the parent directory for a custom credentials path", async () => {
+    it("should not harden existing custom parent directories", async () => {
       const customCredentialsPath = path.join(
         "/tmp",
         "custom-aws",
@@ -640,12 +640,8 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
         recursive: true,
         mode: 0o700,
       });
-      expect(chmod).toHaveBeenNthCalledWith(
-        1,
-        path.dirname(customCredentialsPath),
-        0o700,
-      );
-      expect(chmod).toHaveBeenNthCalledWith(2, customCredentialsPath, 0o600);
+      expect(chmod).toHaveBeenCalledTimes(1);
+      expect(chmod).toHaveBeenCalledWith(customCredentialsPath, 0o600);
     });
 
     it("should not harden the current working directory for relative target paths", async () => {

--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -3,6 +3,7 @@ import _debug from "debug";
 import { paths } from "./paths";
 import { chmod, mkdir } from "node:fs/promises";
 import fs from "fs";
+import path from "path";
 import util from "util";
 
 const debug = _debug("az2aws");
@@ -169,11 +170,12 @@ export const awsConfig = {
   async _loadAsync<T extends Record<string, unknown>>(
     type: string,
   ): Promise<T | undefined> {
-    if (!paths[type]) throw new Error(`Unknown config type: '${type}'`);
+    const targetPath = paths[type];
+    if (!targetPath) throw new Error(`Unknown config type: '${type}'`);
 
     return new Promise<T | undefined>((resolve, reject) => {
-      debug(`Loading '${type}' file at '${paths[type]}'`);
-      fs.readFile(paths[type]!, "utf8", (err, data) => {
+      debug(`Loading '${type}' file at '${targetPath}'`);
+      fs.readFile(targetPath, "utf8", (err, data) => {
         if (err) {
           if (err.code === "ENOENT") {
             debug(`File not found. Returning undefined.`);
@@ -191,18 +193,20 @@ export const awsConfig = {
   },
 
   async _saveAsync(type: string, data: SaveData): Promise<void> {
-    if (!paths[type]) throw new Error(`Unknown config type: '${type}'`);
+    const targetPath = paths[type];
+    if (!targetPath) throw new Error(`Unknown config type: '${type}'`);
     if (!data) throw new Error(`You must provide data for saving.`);
 
     debug(`Stringifying ${type} INI data`);
     const text = ini.stringify(data);
+    const targetDir = path.dirname(targetPath);
 
-    debug(`Creating AWS config directory '${paths.awsDir}' if not exists.`);
-    await mkdir(paths.awsDir, { recursive: true, mode: awsDirMode });
-    await hardenPathPermissions(paths.awsDir, awsDirMode);
+    debug(`Creating target directory '${targetDir}' if not exists.`);
+    await mkdir(targetDir, { recursive: true, mode: awsDirMode });
+    await hardenPathPermissions(targetDir, awsDirMode);
 
-    debug(`Writing '${type}' INI to file '${paths[type]}'`);
-    await writeFile(paths[type], text);
-    await hardenPathPermissions(paths[type], awsFileMode);
+    debug(`Writing '${type}' INI to file '${targetPath}'`);
+    await writeFile(targetPath, text);
+    await hardenPathPermissions(targetPath, awsFileMode);
   },
 };

--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -41,6 +41,45 @@ async function hardenPathPermissions(
   }
 }
 
+async function hardenCreatedDirectories(
+  createdDir: string,
+  targetDir: string,
+): Promise<void> {
+  const resolvedCreatedDir = path.resolve(createdDir);
+  const resolvedTargetDir = path.resolve(targetDir);
+  const relativeTargetDir = path.relative(
+    resolvedCreatedDir,
+    resolvedTargetDir,
+  );
+
+  if (
+    relativeTargetDir === ".." ||
+    relativeTargetDir.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeTargetDir)
+  ) {
+    debug(
+      `Skipping permission hardening because created directory '${createdDir}' is not within target directory '${targetDir}'.`,
+    );
+    return;
+  }
+
+  let currentDir = resolvedCreatedDir;
+  await hardenPathPermissions(currentDir, awsDirMode);
+
+  if (!relativeTargetDir) {
+    return;
+  }
+
+  for (const segment of relativeTargetDir.split(path.sep)) {
+    if (!segment || segment === ".") {
+      continue;
+    }
+
+    currentDir = path.join(currentDir, segment);
+    await hardenPathPermissions(currentDir, awsDirMode);
+  }
+}
+
 // Autorefresh credential time limit in milliseconds
 const refreshLimitInMs = 11 * 60 * 1000;
 
@@ -200,11 +239,25 @@ export const awsConfig = {
     debug(`Stringifying ${type} INI data`);
     const text = ini.stringify(data);
     const targetDir = path.dirname(targetPath);
+    const isDefaultAwsDir =
+      path.resolve(targetDir) === path.resolve(paths.awsDir);
 
     if (targetDir !== ".") {
       debug(`Creating target directory '${targetDir}' if not exists.`);
-      await mkdir(targetDir, { recursive: true, mode: awsDirMode });
-      await hardenPathPermissions(targetDir, awsDirMode);
+      const createdDir = await mkdir(targetDir, {
+        recursive: true,
+        mode: awsDirMode,
+      });
+
+      if (isDefaultAwsDir) {
+        await hardenPathPermissions(targetDir, awsDirMode);
+      } else if (createdDir) {
+        await hardenCreatedDirectories(createdDir, targetDir);
+      } else {
+        debug(
+          `Skipping directory permission hardening for existing custom directory '${targetDir}'.`,
+        );
+      }
     } else {
       debug(
         `Skipping target directory creation for '${targetPath}' because it uses the current working directory.`,

--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -58,7 +58,7 @@ async function hardenCreatedDirectories(
     path.isAbsolute(relativeTargetDir)
   ) {
     debug(
-      `Skipping permission hardening because created directory '${createdDir}' is not within target directory '${targetDir}'.`,
+      `Skipping permission hardening because target directory '${targetDir}' is not within created directory '${createdDir}'.`,
     );
     return;
   }

--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -21,7 +21,7 @@ const ignoredChmodErrorCodes = new Set([
 ]);
 
 async function hardenPathPermissions(
-  path: string,
+  fsPath: string,
   mode: number,
 ): Promise<void> {
   if (process.platform === "win32") {
@@ -29,11 +29,11 @@ async function hardenPathPermissions(
   }
 
   try {
-    await chmod(path, mode);
+    await chmod(fsPath, mode);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (typeof code === "string" && ignoredChmodErrorCodes.has(code)) {
-      debug(`Skipping permission hardening for '${path}' due to ${code}`);
+      debug(`Skipping permission hardening for '${fsPath}' due to ${code}`);
       return;
     }
 
@@ -201,9 +201,15 @@ export const awsConfig = {
     const text = ini.stringify(data);
     const targetDir = path.dirname(targetPath);
 
-    debug(`Creating target directory '${targetDir}' if not exists.`);
-    await mkdir(targetDir, { recursive: true, mode: awsDirMode });
-    await hardenPathPermissions(targetDir, awsDirMode);
+    if (targetDir !== ".") {
+      debug(`Creating target directory '${targetDir}' if not exists.`);
+      await mkdir(targetDir, { recursive: true, mode: awsDirMode });
+      await hardenPathPermissions(targetDir, awsDirMode);
+    } else {
+      debug(
+        `Skipping target directory creation for '${targetPath}' because it uses the current working directory.`,
+      );
+    }
 
     debug(`Writing '${type}' INI to file '${targetPath}'`);
     await writeFile(targetPath, text);


### PR DESCRIPTION
## Summary
- create the parent directory for the active AWS config or credentials file path before writing
- keep default ~/.aws behavior unchanged while honoring AWS path overrides
- add regression coverage for custom config and custom credentials paths

## Testing
- pnpm test -- src/awsConfig.test.ts
- pnpm lint

Fixes #163