### PR TITLE
Fix --no-prompt on account selection screen

### DIFF
--- a/src/loginStates.test.ts
+++ b/src/loginStates.test.ts
@@ -410,6 +410,34 @@ describe("loginStates", () => {
       consoleSpy.mockRestore();
     });
 
+    it("should use default account when noPrompt is true", async () => {
+      const mockPage = createMockPage();
+      const mockAadTile = {};
+      const mockMsaTile = {};
+      mockPage.$.mockImplementation((selector: string) => {
+        if (selector === "#aadTileTitle") return Promise.resolve(mockAadTile);
+        if (selector === "#msaTileTitle") return Promise.resolve(mockMsaTile);
+        return Promise.resolve(null);
+      });
+      mockPage.evaluate.mockImplementation((_fn: unknown, el: unknown) => {
+        if (el === mockAadTile) return Promise.resolve("Work Account");
+        if (el === mockMsaTile) return Promise.resolve("Personal Account");
+        return Promise.resolve("");
+      });
+
+      await getAccountSelectionState().handler(
+        mockPage as never,
+        createMockElementHandle() as never,
+        true,
+        "",
+        undefined,
+        false,
+      );
+
+      expect(inquirer.prompt).not.toHaveBeenCalled();
+      expect(mockPage.click).toHaveBeenCalledWith("#aadTileTitle");
+    });
+
     it("should throw Error when inquirer returns unknown account", async () => {
       const mockPage = createMockPage();
       const mockAadTile = {};

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -131,7 +131,11 @@ export const states: State[] = [
   {
     name: "account selection",
     selector: `#aadTile > div > div.table-cell.tile-img > img`,
-    async handler(page: Page): Promise<void> {
+    async handler(
+      page: Page,
+      _selected: ElementHandle,
+      noPrompt: boolean,
+    ): Promise<void> {
       debug("Multiple accounts associated with username.");
       const aadTile = await page.$("#aadTileTitle");
       const aadTileMessage = await readTextContent(page, aadTile);
@@ -149,6 +153,11 @@ export const states: State[] = [
         throw new CLIError("No accounts found on account selection screen.");
       } else if (accounts.length === 1) {
         account = accounts[0];
+      } else if (noPrompt) {
+        debug("Skipping account prompt and using default account");
+        account = accounts.find((candidate) => {
+          return candidate.message === aadTileMessage;
+        });
       } else {
         debug("Asking user to choose account");
         console.log(


### PR DESCRIPTION
## Summary
- honor --no-prompt on the Microsoft multi-account selection screen
- keep the existing default choice by selecting the AAD tile when running non-interactively
- add coverage for the non-interactive account selection flow

## Testing
- pnpm test

Closes #164