### PR TITLE
ci: add macOS CI coverage and separate E2E job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
+.env*
 .git
 .github
 .claude
@@ -9,6 +10,8 @@ issue
 *.md
 tsconfig.json
 vitest.config.ts
+vitest.e2e.config.ts
 .eslintrc.json
 .release-please-manifest.json
 release-please-config.json
+snapcraft.yaml

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# ── E2E smoke test (pnpm test:e2e) ──────────────────────────────
+
+# Required
+AZ2AWS_E2E_AZURE_TENANT_ID=
+AZ2AWS_E2E_AZURE_APP_ID_URI=
+AZ2AWS_E2E_AZURE_DEFAULT_USERNAME=
+AZ2AWS_E2E_AZURE_DEFAULT_PASSWORD=
+AZ2AWS_E2E_AZURE_DEFAULT_ROLE_ARN=
+
+# Optional (defaults shown)
+# AZ2AWS_E2E_MODE=cli          # cli | debug (visible browser + auto-fill) | gui (fully manual)
+# AZ2AWS_E2E_PROFILE=e2e
+# AZ2AWS_E2E_AWS_REGION=us-east-1
+# AZ2AWS_E2E_DURATION_HOURS=1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
     timeout-minutes: 20
     env:
       PUPPETEER_SKIP_DOWNLOAD: "1"
+      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
       AZ2AWS_E2E_AZURE_TENANT_ID: ${{ secrets.AZ2AWS_E2E_AZURE_TENANT_ID }}
       AZ2AWS_E2E_AZURE_APP_ID_URI: ${{ secrets.AZ2AWS_E2E_AZURE_APP_ID_URI }}
       AZ2AWS_E2E_AZURE_DEFAULT_USERNAME: ${{ secrets.AZ2AWS_E2E_AZURE_DEFAULT_USERNAME }}
@@ -69,6 +70,9 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: mkdir -p "$PUPPETEER_CACHE_DIR"
       - name: Install Chrome and Linux browser dependencies
-        run: sudo env "PATH=$PATH" pnpm exec puppeteer browsers install chrome --install-deps
+        run: sudo --preserve-env=PUPPETEER_CACHE_DIR,HOME,PATH pnpm exec puppeteer browsers install chrome --install-deps
+      - name: Restore Puppeteer cache ownership
+        run: sudo chown -R "$(id -u):$(id -g)" "$PUPPETEER_CACHE_DIR"
       - run: pnpm test:e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,6 +22,7 @@ jobs:
         os:
           - ubuntu-slim
           - windows-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -33,7 +35,7 @@ jobs:
       - run: pnpm lint
       - if: matrix.os == 'ubuntu-slim'
         run: pnpm test:coverage
-      - if: matrix.os == 'windows-latest'
+      - if: matrix.os != 'ubuntu-slim'
         run: pnpm test
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-slim'
@@ -44,3 +46,29 @@ jobs:
           fail_ci_if_error: false
           verbose: true
       - run: pnpm build
+
+  e2e:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    needs: build
+    runs-on: ubuntu-slim
+    timeout-minutes: 20
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: "1"
+      AZ2AWS_E2E_AZURE_TENANT_ID: ${{ secrets.AZ2AWS_E2E_AZURE_TENANT_ID }}
+      AZ2AWS_E2E_AZURE_APP_ID_URI: ${{ secrets.AZ2AWS_E2E_AZURE_APP_ID_URI }}
+      AZ2AWS_E2E_AZURE_DEFAULT_USERNAME: ${{ secrets.AZ2AWS_E2E_AZURE_DEFAULT_USERNAME }}
+      AZ2AWS_E2E_AZURE_DEFAULT_PASSWORD: ${{ secrets.AZ2AWS_E2E_AZURE_DEFAULT_PASSWORD }}
+      AZ2AWS_E2E_AZURE_DEFAULT_ROLE_ARN: ${{ secrets.AZ2AWS_E2E_AZURE_DEFAULT_ROLE_ARN }}
+      AZ2AWS_E2E_AWS_REGION: ${{ vars.AZ2AWS_E2E_AWS_REGION }}
+      AZ2AWS_E2E_DURATION_HOURS: ${{ vars.AZ2AWS_E2E_DURATION_HOURS }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Install Chrome and Linux browser dependencies
+        run: sudo env "PATH=$PATH" pnpm exec puppeteer browsers install chrome --install-deps
+      - run: pnpm test:e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   build:
     env:
+      # Build job does not need Chrome; skip the postinstall download.
       PUPPETEER_SKIP_DOWNLOAD: "1"
     strategy:
       fail-fast: false
@@ -56,6 +57,9 @@ jobs:
     timeout-minutes: 20
     env:
       CI: "true"
+      # Skip the postinstall download; Chrome is installed explicitly
+      # via "puppeteer browsers install chrome --install-deps" below
+      # so that --install-deps can also pull the required Linux libs.
       PUPPETEER_SKIP_DOWNLOAD: "1"
       PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
       AZ2AWS_E2E_AZURE_TENANT_ID: ${{ secrets.AZ2AWS_E2E_AZURE_TENANT_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,11 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -39,12 +41,12 @@ jobs:
         run: pnpm test
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-slim'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           fail_ci_if_error: false
-          verbose: true
+          verbose: false
       - run: pnpm build
 
   e2e:
@@ -64,9 +66,11 @@ jobs:
       AZ2AWS_E2E_AWS_REGION: ${{ vars.AZ2AWS_E2E_AWS_REGION }}
       AZ2AWS_E2E_DURATION_HOURS: ${{ vars.AZ2AWS_E2E_DURATION_HOURS }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 20
     env:
+      CI: "true"
       PUPPETEER_SKIP_DOWNLOAD: "1"
       PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
       AZ2AWS_E2E_AZURE_TENANT_ID: ${{ secrets.AZ2AWS_E2E_AZURE_TENANT_ID }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,13 +17,13 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,20 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-  packages: write
-  id-token: write
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -26,7 +27,7 @@ jobs:
       - run: pnpm test
       - run: pnpm build
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: lib
           path: lib
@@ -38,14 +39,16 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lib
           path: lib
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -57,17 +60,21 @@ jobs:
   publish-docker:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lib
           path: lib
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/az2aws
           tags: |
@@ -77,13 +84,13 @@ jobs:
             type=raw,value=latest
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: ./Dockerfile
@@ -94,20 +101,24 @@ jobs:
   publish-snap:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lib
           path: lib
 
-      - uses: snapcore/action-build@v1
+      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
         id: build
         with:
           snapcraft-args: --destructive-mode
 
-      - uses: snapcore/action-publish@v1
+      - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ node_modules
 
 lib
 .worktrees/
+az2aws-unrecognized-state.png

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.env*
 .github
 .claude
 src
@@ -10,6 +11,7 @@ issue
 .release-please-manifest.json
 release-please-config.json
 vitest.config.ts
+vitest.e2e.config.ts
 docker-launch.sh
 Dockerfile
 snapcraft.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,11 @@ logs stream directly to the terminal. When troubleshooting a live failure, rerun
 with `AZ2AWS_E2E_MODE=debug pnpm test:e2e` to keep the browser visible while the
 CLI state machine continues driving the flow.
 
+`AZ2AWS_E2E_MODE=debug` keeps the browser visible and still auto-fills the page
+through the CLI state machine. `AZ2AWS_E2E_MODE=gui` is fully manual: it opens
+the browser and waits for you to complete the login yourself, so defaults such
+as the email address are not auto-entered.
+
 `pnpm test:e2e` does not support passkey-first accounts that require the saved
 passkey prompt for `login.microsoft.com`. That UI is rendered by the
 browser/OS passkey layer rather than the page DOM, so the current

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,13 @@ through the CLI state machine. `AZ2AWS_E2E_MODE=gui` is fully manual: it opens
 the browser and waits for you to complete the login yourself, so defaults such
 as the email address are not auto-entered.
 
+Local `pnpm test:e2e` runs still print the final `credential_process` JSON so
+you can inspect the temporary credentials directly. CI runs suppress that JSON
+when `CI=true` or `GITHUB_ACTIONS=true` to avoid leaking credentials into build
+logs. GitHub Actions already provides `GITHUB_ACTIONS=true`, and
+`.github/workflows/main.yml` also sets `CI=true` explicitly for the `e2e` job
+to make that intent obvious.
+
 `pnpm test:e2e` does not support passkey-first accounts that require the saved
 passkey prompt for `login.microsoft.com`. That UI is rendered by the
 browser/OS passkey layer rather than the page DOM, so the current

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,10 +90,35 @@ pnpm build && node ./lib/index.js
 | `pnpm build` | Build for production |
 | `pnpm test` | Run unit tests |
 | `pnpm test:coverage` | Run unit tests with coverage |
+| `pnpm test:e2e` | Run the live Azure→AWS browser smoke test |
 | `pnpm lint` | Run ESLint and formatting checks |
 | `pnpm eslint` | Run ESLint |
 | `pnpm prettier:check` | Check code formatting |
 | `pnpm prettier:write` | Auto-fix code formatting |
+
+### E2E Smoke Test
+
+`pnpm test:e2e` is intentionally separate from `pnpm test`. It launches a real
+Puppeteer/Chrome session, signs in through Azure AD, and verifies that az2aws
+can retrieve AWS credentials in `credential_process` mode without persisting
+them to the shared credentials file.
+
+Required environment variables:
+
+- `AZ2AWS_E2E_AZURE_TENANT_ID`
+- `AZ2AWS_E2E_AZURE_APP_ID_URI`
+- `AZ2AWS_E2E_AZURE_DEFAULT_USERNAME`
+- `AZ2AWS_E2E_AZURE_DEFAULT_PASSWORD`
+- `AZ2AWS_E2E_AZURE_DEFAULT_ROLE_ARN`
+
+Optional environment variables:
+
+- `AZ2AWS_E2E_PROFILE` (defaults to `e2e`)
+- `AZ2AWS_E2E_AWS_REGION` (defaults to `us-east-1`)
+- `AZ2AWS_E2E_DURATION_HOURS` (defaults to `1`)
+
+CI only runs this smoke test on `push` to `main` and `workflow_dispatch`, so PR
+validation stays fast and does not depend on repository secrets.
 
 ## Development Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,9 +113,26 @@ Required environment variables:
 
 Optional environment variables:
 
+- `AZ2AWS_E2E_MODE` (defaults to `cli`; use `debug` or `gui` for interactive troubleshooting)
 - `AZ2AWS_E2E_PROFILE` (defaults to `e2e`)
 - `AZ2AWS_E2E_AWS_REGION` (defaults to `us-east-1`)
 - `AZ2AWS_E2E_DURATION_HOURS` (defaults to `1`)
+
+`pnpm test:e2e` enables `DEBUG=az2aws` by default when `DEBUG` is not already
+set, and the E2E Vitest config disables console interception so browser flow
+logs stream directly to the terminal. When troubleshooting a live failure, rerun
+with `AZ2AWS_E2E_MODE=debug pnpm test:e2e` to keep the browser visible while the
+CLI state machine continues driving the flow.
+
+`pnpm test:e2e` does not support passkey-first accounts that require the saved
+passkey prompt for `login.microsoft.com`. That UI is rendered by the
+browser/OS passkey layer rather than the page DOM, so the current
+Puppeteer-driven flow cannot dismiss it in `cli` mode. Use a dedicated E2E
+account that can continue with the standard username/password/MFA page flow.
+
+If the run times out before it ever reaches `input[name="loginfmt"]`, the E2E
+test now treats that account as unsupported and surfaces a passkey-specific
+error message instead of only showing the raw selector timeout.
 
 CI only runs this smoke test on `push` to `main` and `workflow_dispatch`, so PR
 validation stays fast and does not depend on repository secrets.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,11 +118,13 @@ Optional environment variables:
 - `AZ2AWS_E2E_AWS_REGION` (defaults to `us-east-1`)
 - `AZ2AWS_E2E_DURATION_HOURS` (defaults to `1`)
 
-`pnpm test:e2e` enables `DEBUG=az2aws` by default when `DEBUG` is not already
-set, and the E2E Vitest config disables console interception so browser flow
-logs stream directly to the terminal. When troubleshooting a live failure, rerun
-with `AZ2AWS_E2E_MODE=debug pnpm test:e2e` to keep the browser visible while the
-CLI state machine continues driving the flow.
+Local `pnpm test:e2e` enables `DEBUG=az2aws` by default when `DEBUG` is not
+already set, and the E2E Vitest config disables console interception so browser
+flow logs stream directly to the terminal. CI runs force `DEBUG` off by default
+to avoid leaking sensitive browser flow details into public GitHub Actions logs.
+When troubleshooting a live failure, rerun locally with
+`AZ2AWS_E2E_MODE=debug pnpm test:e2e` to keep the browser visible while the CLI
+state machine continues driving the flow.
 
 `AZ2AWS_E2E_MODE=debug` keeps the browser visible and still auto-fills the page
 through the CLI state machine. `AZ2AWS_E2E_MODE=gui` is fully manual: it opens

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,58 +98,22 @@ pnpm build && node ./lib/index.js
 
 ### E2E Smoke Test
 
-`pnpm test:e2e` is intentionally separate from `pnpm test`. It launches a real
-Puppeteer/Chrome session, signs in through Azure AD, and verifies that az2aws
-can retrieve AWS credentials in `credential_process` mode without persisting
-them to the shared credentials file.
+`pnpm test:e2e` launches a real Puppeteer/Chrome session, signs in through
+Azure AD, and verifies that az2aws can retrieve AWS credentials via
+`credential_process` without persisting them to the shared credentials file.
 
-Required environment variables:
+Copy `.env.example` to `.env` and fill in the values. See
+[`vitest.e2e.config.ts`](vitest.e2e.config.ts) for the Vitest settings used by
+this suite.
 
-- `AZ2AWS_E2E_AZURE_TENANT_ID`
-- `AZ2AWS_E2E_AZURE_APP_ID_URI`
-- `AZ2AWS_E2E_AZURE_DEFAULT_USERNAME`
-- `AZ2AWS_E2E_AZURE_DEFAULT_PASSWORD`
-- `AZ2AWS_E2E_AZURE_DEFAULT_ROLE_ARN`
+To troubleshoot a failing run, rerun with `AZ2AWS_E2E_MODE=debug` (visible
+browser, auto-fill) or `AZ2AWS_E2E_MODE=gui` (fully manual).
 
-Optional environment variables:
+> **Note:** Passkey-first Microsoft accounts are not supported — use a dedicated
+> account with standard username/password/MFA.
 
-- `AZ2AWS_E2E_MODE` (defaults to `cli`; use `debug` or `gui` for interactive troubleshooting)
-- `AZ2AWS_E2E_PROFILE` (defaults to `e2e`)
-- `AZ2AWS_E2E_AWS_REGION` (defaults to `us-east-1`)
-- `AZ2AWS_E2E_DURATION_HOURS` (defaults to `1`)
-
-Local `pnpm test:e2e` enables `DEBUG=az2aws` by default when `DEBUG` is not
-already set, and the E2E Vitest config disables console interception so browser
-flow logs stream directly to the terminal. CI runs force `DEBUG` off by default
-to avoid leaking sensitive browser flow details into public GitHub Actions logs.
-When troubleshooting a live failure, rerun locally with
-`AZ2AWS_E2E_MODE=debug pnpm test:e2e` to keep the browser visible while the CLI
-state machine continues driving the flow.
-
-`AZ2AWS_E2E_MODE=debug` keeps the browser visible and still auto-fills the page
-through the CLI state machine. `AZ2AWS_E2E_MODE=gui` is fully manual: it opens
-the browser and waits for you to complete the login yourself, so defaults such
-as the email address are not auto-entered.
-
-Local `pnpm test:e2e` runs still print the final `credential_process` JSON so
-you can inspect the temporary credentials directly. CI runs suppress that JSON
-when `CI=true` or `GITHUB_ACTIONS=true` to avoid leaking credentials into build
-logs. GitHub Actions already provides `GITHUB_ACTIONS=true`, and
-`.github/workflows/main.yml` also sets `CI=true` explicitly for the `e2e` job
-to make that intent obvious.
-
-`pnpm test:e2e` does not support passkey-first accounts that require the saved
-passkey prompt for `login.microsoft.com`. That UI is rendered by the
-browser/OS passkey layer rather than the page DOM, so the current
-Puppeteer-driven flow cannot dismiss it in `cli` mode. Use a dedicated E2E
-account that can continue with the standard username/password/MFA page flow.
-
-If the run times out before it ever reaches `input[name="loginfmt"]`, the E2E
-test now treats that account as unsupported and surfaces a passkey-specific
-error message instead of only showing the raw selector timeout.
-
-CI only runs this smoke test on `push` to `main` and `workflow_dispatch`, so PR
-validation stays fast and does not depend on repository secrets.
+CI only runs this test on `push` to `main` and `workflow_dispatch`; PR
+validation does not depend on repository secrets.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ If you see device compliance errors (e.g., "Device UnSecured Or Non-Compliant"),
 Try:
  `--mode gui` and use your system Chrome via `BROWSER_CHROME_BIN`.
 
+If your Microsoft account requires a saved passkey prompt before the username
+or password page appears, that flow is unsupported in `az2aws --mode cli`.
+The prompt is rendered by the browser/OS passkey UI instead of the page DOM,
+so az2aws cannot dismiss it automatically. Use `--mode gui` and handle it
+manually, or use an account that can continue with the standard page-based
+username/password/MFA flow.
+
 If you see "Unable to recognize page state!", Azure's login pages may have
 changed. Try:
 

--- a/README.md
+++ b/README.md
@@ -220,9 +220,14 @@ Example:
     az2aws                    # Default profile
     az2aws --profile foo      # Named profile
     az2aws --mode gui         # Use browser UI (more reliable)
+    az2aws --mode debug       # Show the browser while az2aws still drives the flow
     az2aws --mode gui --incognito  # Open a fresh incognito login window
 
 You'll be prompted for username, password, and MFA if required. After login, use AWS CLI/SDKs as usual.
+
+`--mode gui` is fully manual and waits for you to complete the browser flow
+yourself. If you want the browser to stay visible while az2aws still auto-fills
+the login steps, use `--mode debug`.
 
 **Tips:**
 - Set `AWS_PROFILE` env var instead of using `--profile`

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "prettier:write": "prettier --write \"src/**/*.{ts,json}\"",
     "prettier:check": "prettier --check \"src/**/*.ts\"",
     "test": "vitest run",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "pnpm eslint && pnpm prettier:check"

--- a/src/awsConfig.test.ts
+++ b/src/awsConfig.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
-import { chmod, mkdir } from "node:fs/promises";
+import { chmod, mkdir, rename, rm } from "node:fs/promises";
 import os from "os";
 import path from "path";
 import { awsConfig } from "./awsConfig";
@@ -10,6 +10,8 @@ vi.mock("fs");
 vi.mock("node:fs/promises", () => ({
   mkdir: vi.fn().mockResolvedValue(undefined),
   chmod: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined),
+  rm: vi.fn().mockResolvedValue(undefined),
 }));
 
 const defaultConfigPath = paths.config;
@@ -563,6 +565,10 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
       ).resolves.toBeUndefined();
 
       expect(fs.writeFile).toHaveBeenCalled();
+      expect(rename).toHaveBeenCalledWith(
+        expect.stringMatching(/(^|[\\/])\.config\..+\.tmp$/),
+        paths.config,
+      );
       expect(mkdir).toHaveBeenCalledWith(path.dirname(paths.config), {
         recursive: true,
         mode: 0o700,
@@ -573,7 +579,12 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
           path.dirname(paths.config),
           0o700,
         );
-        expect(chmod).toHaveBeenNthCalledWith(2, paths.config, 0o600);
+        expect(chmod).toHaveBeenNthCalledWith(
+          2,
+          expect.stringMatching(/(^|[\\/])\.config\..+\.tmp$/),
+          0o600,
+        );
+        expect(chmod).toHaveBeenNthCalledWith(3, paths.config, 0o600);
       } else {
         expect(chmod).not.toHaveBeenCalled();
       }
@@ -609,10 +620,19 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
         recursive: true,
         mode: 0o700,
       });
+      expect(rename).toHaveBeenCalledWith(
+        expect.stringMatching(/(^|[\\/])\.config\..+\.tmp$/),
+        customConfigPath,
+      );
       if (supportsPermissionHardening) {
         expect(chmod).toHaveBeenNthCalledWith(1, customConfigDir, 0o700);
         expect(chmod).toHaveBeenNthCalledWith(2, nestedCustomConfigDir, 0o700);
-        expect(chmod).toHaveBeenNthCalledWith(3, customConfigPath, 0o600);
+        expect(chmod).toHaveBeenNthCalledWith(
+          3,
+          expect.stringMatching(/(^|[\\/])\.config\..+\.tmp$/),
+          0o600,
+        );
+        expect(chmod).toHaveBeenNthCalledWith(4, customConfigPath, 0o600);
       } else {
         expect(chmod).not.toHaveBeenCalled();
       }
@@ -652,8 +672,13 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
         mode: 0o700,
       });
       if (supportsPermissionHardening) {
-        expect(chmod).toHaveBeenCalledTimes(1);
-        expect(chmod).toHaveBeenCalledWith(customCredentialsPath, 0o600);
+        expect(chmod).toHaveBeenCalledTimes(2);
+        expect(chmod).toHaveBeenNthCalledWith(
+          1,
+          expect.stringMatching(/(^|[\\/])\.credentials\..+\.tmp$/),
+          0o600,
+        );
+        expect(chmod).toHaveBeenNthCalledWith(2, customCredentialsPath, 0o600);
       } else {
         expect(chmod).not.toHaveBeenCalled();
       }
@@ -683,8 +708,13 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
 
       expect(mkdir).not.toHaveBeenCalled();
       if (supportsPermissionHardening) {
-        expect(chmod).toHaveBeenCalledTimes(1);
-        expect(chmod).toHaveBeenCalledWith("config", 0o600);
+        expect(chmod).toHaveBeenCalledTimes(2);
+        expect(chmod).toHaveBeenNthCalledWith(
+          1,
+          expect.stringMatching(/^\.config\..+\.tmp$/),
+          0o600,
+        );
+        expect(chmod).toHaveBeenNthCalledWith(2, "config", 0o600);
       } else {
         expect(chmod).not.toHaveBeenCalled();
       }
@@ -721,7 +751,7 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
 
       expect(fs.writeFile).toHaveBeenCalled();
       if (supportsPermissionHardening) {
-        expect(chmod).toHaveBeenCalledTimes(2);
+        expect(chmod).toHaveBeenCalledTimes(3);
       } else {
         expect(chmod).not.toHaveBeenCalled();
       }
@@ -754,6 +784,33 @@ aws_session_token = FwoGZXIvYXdzEBYaDH+token/with+special==chars
         await expect(savePromise).resolves.toBeUndefined();
         expect(chmod).not.toHaveBeenCalled();
       }
+    });
+
+    it("should clean up temporary files when atomic rename fails", async () => {
+      vi.mocked(fs.writeFile).mockImplementation(
+        (
+          _path: fs.PathOrFileDescriptor,
+          _data: string | NodeJS.ArrayBufferView,
+          callback: fs.NoParamCallback,
+        ) => {
+          callback(null);
+        },
+      );
+      vi.mocked(rename).mockRejectedValueOnce(new Error("rename failed"));
+
+      await expect(
+        awsConfig._saveAsync("config", {
+          default: {
+            azure_tenant_id: "test-tenant",
+            azure_app_id_uri: "https://app.example.com",
+          } as never,
+        }),
+      ).rejects.toThrow("rename failed");
+
+      expect(rm).toHaveBeenCalledWith(
+        expect.stringMatching(/(^|[\\/])\.config\..+\.tmp$/),
+        { force: true },
+      );
     });
   });
 

--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -295,6 +295,9 @@ export const awsConfig = {
 
     debug(`Writing '${type}' INI to file atomically`);
     await atomicWriteTextFile(targetPath, text);
+    // Defensive: atomicWriteTextFile already sets permissions on the temp file
+    // before rename, but we re-apply here in case rename semantics differ across
+    // platforms or file-systems.
     await hardenPathPermissions(targetPath, awsFileMode);
   },
 };

--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -1,8 +1,9 @@
 import ini from "ini";
 import _debug from "debug";
 import { paths } from "./paths";
-import { chmod, mkdir } from "node:fs/promises";
+import { chmod, mkdir, rename, rm } from "node:fs/promises";
 import fs from "fs";
+import crypto from "node:crypto";
 import path from "path";
 import util from "util";
 
@@ -33,7 +34,7 @@ async function hardenPathPermissions(
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (typeof code === "string" && ignoredChmodErrorCodes.has(code)) {
-      debug(`Skipping permission hardening for '${fsPath}' due to ${code}`);
+      debug(`Skipping permission hardening due to ${code}`);
       return;
     }
 
@@ -58,7 +59,7 @@ async function hardenCreatedDirectories(
     path.isAbsolute(relativeTargetDir)
   ) {
     debug(
-      `Skipping permission hardening because target directory '${targetDir}' is not within created directory '${createdDir}'.`,
+      "Skipping permission hardening because the target directory is not within the created directory.",
     );
     return;
   }
@@ -77,6 +78,34 @@ async function hardenCreatedDirectories(
 
     currentDir = path.join(currentDir, segment);
     await hardenPathPermissions(currentDir, awsDirMode);
+  }
+}
+
+async function atomicWriteTextFile(
+  targetPath: string,
+  text: string,
+): Promise<void> {
+  const targetDir = path.dirname(targetPath);
+  const tempPath =
+    targetDir === "."
+      ? `.${path.basename(targetPath)}.${crypto.randomUUID()}.tmp`
+      : path.join(
+          targetDir,
+          `.${path.basename(targetPath)}.${crypto.randomUUID()}.tmp`,
+        );
+
+  let shouldCleanupTempPath = false;
+
+  try {
+    await writeFile(tempPath, text);
+    shouldCleanupTempPath = true;
+    await hardenPathPermissions(tempPath, awsFileMode);
+    await rename(tempPath, targetPath);
+    shouldCleanupTempPath = false;
+  } finally {
+    if (shouldCleanupTempPath) {
+      await rm(tempPath, { force: true }).catch(() => undefined);
+    }
   }
 }
 
@@ -213,7 +242,7 @@ export const awsConfig = {
     if (!targetPath) throw new Error(`Unknown config type: '${type}'`);
 
     return new Promise<T | undefined>((resolve, reject) => {
-      debug(`Loading '${type}' file at '${targetPath}'`);
+      debug(`Loading '${type}' file`);
       fs.readFile(targetPath, "utf8", (err, data) => {
         if (err) {
           if (err.code === "ENOENT") {
@@ -243,7 +272,7 @@ export const awsConfig = {
       path.resolve(targetDir) === path.resolve(paths.awsDir);
 
     if (targetDir !== ".") {
-      debug(`Creating target directory '${targetDir}' if not exists.`);
+      debug(`Creating target directory for '${type}' if it does not exist.`);
       const createdDir = await mkdir(targetDir, {
         recursive: true,
         mode: awsDirMode,
@@ -255,17 +284,17 @@ export const awsConfig = {
         await hardenCreatedDirectories(createdDir, targetDir);
       } else {
         debug(
-          `Skipping directory permission hardening for existing custom directory '${targetDir}'.`,
+          "Skipping directory permission hardening for existing custom directory.",
         );
       }
     } else {
       debug(
-        `Skipping target directory creation for '${targetPath}' because it uses the current working directory.`,
+        `Skipping target directory creation for '${type}' because it uses the current working directory.`,
       );
     }
 
-    debug(`Writing '${type}' INI to file '${targetPath}'`);
-    await writeFile(targetPath, text);
+    debug(`Writing '${type}' INI to file atomically`);
+    await atomicWriteTextFile(targetPath, text);
     await hardenPathPermissions(targetPath, awsFileMode);
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ process.on("SIGTERM", () => process.exit(1));
 import { Command } from "commander";
 import { configureProfileAsync } from "./configureProfileAsync";
 import { login } from "./login";
+import {
+  formatCliErrorMessage,
+  formatUnexpectedErrorMessage,
+} from "./sensitiveOutput";
 import { checkForUpdate } from "./updateNotifier";
 import { validateCliOptions } from "./validateCliOptions";
 
@@ -130,10 +134,13 @@ async function runAsync(): Promise<void> {
     }
   } catch (err: unknown) {
     if (err instanceof Error && err.name === "CLIError") {
-      console.error(err.message);
+      console.error(formatCliErrorMessage(err.message));
       exitCode = 2;
+    } else if (err instanceof Error) {
+      console.error(formatUnexpectedErrorMessage(err));
+      exitCode = 1;
     } else {
-      console.error(err);
+      console.error(formatUnexpectedErrorMessage(err));
       exitCode = 1;
     }
   }

--- a/src/login.e2e.test.ts
+++ b/src/login.e2e.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 interface E2eConfig {
   appIdUri: string;
   durationHours: string;
+  mode: string;
   password: string;
   profileName: string;
   region: string;
@@ -23,6 +24,8 @@ interface CredentialProcessOutput {
 }
 
 const originalEnv = { ...process.env };
+const USERNAME_INPUT_TIMEOUT_MESSAGE =
+  'Waiting for selector `input[name="loginfmt"]` failed';
 
 function getRequiredEnv(name: keyof NodeJS.ProcessEnv): string {
   const value = process.env[name];
@@ -40,6 +43,7 @@ function loadE2eConfig(): E2eConfig {
     username: getRequiredEnv("AZ2AWS_E2E_AZURE_DEFAULT_USERNAME"),
     password: getRequiredEnv("AZ2AWS_E2E_AZURE_DEFAULT_PASSWORD"),
     roleArn: getRequiredEnv("AZ2AWS_E2E_AZURE_DEFAULT_ROLE_ARN"),
+    mode: process.env.AZ2AWS_E2E_MODE?.trim() || "cli",
     profileName: process.env.AZ2AWS_E2E_PROFILE?.trim() || "e2e",
     region: process.env.AZ2AWS_E2E_AWS_REGION?.trim() || "us-east-1",
     durationHours: process.env.AZ2AWS_E2E_DURATION_HOURS?.trim() || "1",
@@ -62,6 +66,13 @@ function buildProfileConfig(profileName: string, region: string): string {
   ].join("\n");
 }
 
+function isUsernameInputTimeout(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes(USERNAME_INPUT_TIMEOUT_MESSAGE)
+  );
+}
+
 describe("login e2e", () => {
   it(
     "retrieves live AWS credentials through the Azure SSO flow",
@@ -80,6 +91,7 @@ describe("login e2e", () => {
         ...originalEnv,
         HOME: homeDir,
         USERPROFILE: homeDir,
+        DEBUG: process.env.DEBUG?.trim() || "az2aws",
         AWS_CONFIG_FILE: configPath,
         AWS_SHARED_CREDENTIALS_FILE: credentialsPath,
         AZURE_TENANT_ID: e2eConfig.tenantId,
@@ -102,19 +114,44 @@ describe("login e2e", () => {
         vi.resetModules();
         const { login } = await import("./login");
 
-        await login.loginAsync(
-          e2eConfig.profileName,
-          "cli",
-          true,
-          true,
-          false,
-          false,
-          false,
-          false,
-          true,
-          true,
-          true,
+        console.error(
+          `[az2aws:e2e] tempDir=${tempDir} profile=${e2eConfig.profileName} mode=${e2eConfig.mode} region=${e2eConfig.region}`,
         );
+
+        const disableSandbox = true;
+        const noPrompt = true;
+        const enableChromeNetworkService = false;
+        const awsNoVerifySsl = false;
+        const enableChromeSeamlessSso = false;
+        const noDisableExtensions = false;
+        const disableGpu = true;
+        const incognito = true;
+        const credentialProcess = true;
+
+        try {
+          await login.loginAsync(
+            e2eConfig.profileName,
+            e2eConfig.mode,
+            disableSandbox,
+            noPrompt,
+            enableChromeNetworkService,
+            awsNoVerifySsl,
+            enableChromeSeamlessSso,
+            noDisableExtensions,
+            disableGpu,
+            incognito,
+            credentialProcess,
+          );
+        } catch (error) {
+          if (isUsernameInputTimeout(error)) {
+            throw new Error(
+              "Unsupported E2E account: pnpm test:e2e does not support passkey-first Microsoft accounts that require the browser/OS saved passkey prompt before the page DOM reaches the username form. Use a dedicated account that can continue with password/MFA in the page, or rerun with AZ2AWS_E2E_MODE=debug to confirm the passkey prompt manually.",
+              { cause: error },
+            );
+          }
+
+          throw error;
+        }
 
         const jsonPayload = logSpy.mock.calls.at(-1)?.[0];
 

--- a/src/login.e2e.test.ts
+++ b/src/login.e2e.test.ts
@@ -27,7 +27,7 @@ const originalEnv = { ...process.env };
 const USERNAME_INPUT_TIMEOUT_MESSAGE =
   'Waiting for selector `input[name="loginfmt"]` failed';
 const shouldSuppressCredentialProcessOutput =
-  process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+  !!process.env.CI || !!process.env.GITHUB_ACTIONS;
 
 function getRequiredEnv(name: keyof NodeJS.ProcessEnv): string {
   const value = process.env[name];

--- a/src/login.e2e.test.ts
+++ b/src/login.e2e.test.ts
@@ -1,0 +1,146 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+interface E2eConfig {
+  appIdUri: string;
+  durationHours: string;
+  password: string;
+  profileName: string;
+  region: string;
+  roleArn: string;
+  tenantId: string;
+  username: string;
+}
+
+interface CredentialProcessOutput {
+  AccessKeyId: string;
+  Expiration: string;
+  SecretAccessKey: string;
+  SessionToken: string;
+  Version: number;
+}
+
+const originalEnv = { ...process.env };
+
+function getRequiredEnv(name: keyof NodeJS.ProcessEnv): string {
+  const value = process.env[name];
+  if (!value || !value.trim()) {
+    throw new Error(`Missing required E2E environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function loadE2eConfig(): E2eConfig {
+  return {
+    tenantId: getRequiredEnv("AZ2AWS_E2E_AZURE_TENANT_ID"),
+    appIdUri: getRequiredEnv("AZ2AWS_E2E_AZURE_APP_ID_URI"),
+    username: getRequiredEnv("AZ2AWS_E2E_AZURE_DEFAULT_USERNAME"),
+    password: getRequiredEnv("AZ2AWS_E2E_AZURE_DEFAULT_PASSWORD"),
+    roleArn: getRequiredEnv("AZ2AWS_E2E_AZURE_DEFAULT_ROLE_ARN"),
+    profileName: process.env.AZ2AWS_E2E_PROFILE?.trim() || "e2e",
+    region: process.env.AZ2AWS_E2E_AWS_REGION?.trim() || "us-east-1",
+    durationHours: process.env.AZ2AWS_E2E_DURATION_HOURS?.trim() || "1",
+  };
+}
+
+function buildProfileConfig(profileName: string, region: string): string {
+  const sectionName =
+    profileName === "default" ? "default" : `profile ${profileName}`;
+
+  return [
+    `[${sectionName}]`,
+    `region = ${region}`,
+    "azure_tenant_id = placeholder",
+    "azure_app_id_uri = placeholder",
+    "azure_default_role_arn = placeholder",
+    "azure_default_duration_hours = 1",
+    "azure_default_remember_me = false",
+    "",
+  ].join("\n");
+}
+
+describe("login e2e", () => {
+  it(
+    "retrieves live AWS credentials through the Azure SSO flow",
+    async () => {
+      const e2eConfig = loadE2eConfig();
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "az2aws-e2e-"));
+      const homeDir = path.join(tempDir, "home");
+      const awsDir = path.join(homeDir, ".aws");
+      const configPath = path.join(awsDir, "config");
+      const credentialsPath = path.join(awsDir, "credentials");
+      const logSpy = vi
+        .spyOn(console, "log")
+        .mockImplementation(() => undefined);
+
+      process.env = {
+        ...originalEnv,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        AWS_CONFIG_FILE: configPath,
+        AWS_SHARED_CREDENTIALS_FILE: credentialsPath,
+        AZURE_TENANT_ID: e2eConfig.tenantId,
+        AZURE_APP_ID_URI: e2eConfig.appIdUri,
+        AZURE_DEFAULT_USERNAME: e2eConfig.username,
+        AZURE_DEFAULT_PASSWORD: e2eConfig.password,
+        AZURE_DEFAULT_ROLE_ARN: e2eConfig.roleArn,
+        AZURE_DEFAULT_DURATION_HOURS: e2eConfig.durationHours,
+      };
+
+      try {
+        await mkdir(awsDir, { recursive: true });
+        await writeFile(
+          configPath,
+          buildProfileConfig(e2eConfig.profileName, e2eConfig.region),
+          "utf8",
+        );
+        await writeFile(credentialsPath, "", "utf8");
+
+        vi.resetModules();
+        const { login } = await import("./login");
+
+        await login.loginAsync(
+          e2eConfig.profileName,
+          "cli",
+          true,
+          true,
+          false,
+          false,
+          false,
+          false,
+          true,
+          true,
+          true,
+        );
+
+        const jsonPayload = logSpy.mock.calls.at(-1)?.[0];
+
+        expect(jsonPayload).toBeDefined();
+
+        const credentials = JSON.parse(
+          String(jsonPayload),
+        ) as CredentialProcessOutput;
+
+        expect(credentials.Version).toBe(1);
+        expect(credentials.AccessKeyId).toBeTruthy();
+        expect(credentials.SecretAccessKey).toBeTruthy();
+        expect(credentials.SessionToken).toBeTruthy();
+        expect(new Date(credentials.Expiration).getTime()).toBeGreaterThan(
+          Date.now(),
+        );
+
+        const persistedCredentials = await readFile(credentialsPath, "utf8");
+        expect(persistedCredentials.trim()).toBe("");
+      } finally {
+        process.env = { ...originalEnv };
+        vi.restoreAllMocks();
+        vi.resetModules();
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    },
+    10 * 60 * 1000,
+  );
+});

--- a/src/login.e2e.test.ts
+++ b/src/login.e2e.test.ts
@@ -98,7 +98,9 @@ describe("login e2e", () => {
         ...originalEnv,
         HOME: homeDir,
         USERPROFILE: homeDir,
-        DEBUG: process.env.DEBUG?.trim() || "az2aws",
+        DEBUG: shouldSuppressCredentialProcessOutput
+          ? ""
+          : process.env.DEBUG?.trim() || "az2aws",
         AWS_CONFIG_FILE: configPath,
         AWS_SHARED_CREDENTIALS_FILE: credentialsPath,
         AZURE_TENANT_ID: e2eConfig.tenantId,

--- a/src/login.e2e.test.ts
+++ b/src/login.e2e.test.ts
@@ -26,6 +26,8 @@ interface CredentialProcessOutput {
 const originalEnv = { ...process.env };
 const USERNAME_INPUT_TIMEOUT_MESSAGE =
   'Waiting for selector `input[name="loginfmt"]` failed';
+const shouldSuppressCredentialProcessOutput =
+  process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
 
 function getRequiredEnv(name: keyof NodeJS.ProcessEnv): string {
   const value = process.env[name];
@@ -83,9 +85,14 @@ describe("login e2e", () => {
       const awsDir = path.join(homeDir, ".aws");
       const configPath = path.join(awsDir, "config");
       const credentialsPath = path.join(awsDir, "credentials");
+      const originalConsoleLog = console.log;
       const logSpy = vi
         .spyOn(console, "log")
-        .mockImplementation(() => undefined);
+        .mockImplementation((...args: unknown[]) => {
+          if (!shouldSuppressCredentialProcessOutput) {
+            originalConsoleLog(...args);
+          }
+        });
 
       process.env = {
         ...originalEnv,
@@ -115,7 +122,7 @@ describe("login e2e", () => {
         const { login } = await import("./login");
 
         console.error(
-          `[az2aws:e2e] tempDir=${tempDir} profile=${e2eConfig.profileName} mode=${e2eConfig.mode} region=${e2eConfig.region}`,
+          `[az2aws:e2e] profile=${e2eConfig.profileName} mode=${e2eConfig.mode} region=${e2eConfig.region}`,
         );
 
         const disableSandbox = true;

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -170,34 +170,6 @@ describe("login", () => {
     });
   });
 
-  describe("_redactUrlForDebug", () => {
-    it("should redact tenant path segments and query parameter values from login URLs", () => {
-      expect(
-        login._redactUrlForDebug(
-          "https://login.microsoftonline.com/tenant/saml2?SAMLRequest=abc123&foo=bar",
-        ),
-      ).toBe(
-        "https://login.microsoftonline.com/[redacted]/saml2?SAMLRequest=%5Bredacted%5D&foo=%5Bredacted%5D",
-      );
-    });
-
-    it("should leave URLs without query parameters unchanged", () => {
-      expect(
-        login._redactUrlForDebug("https://signin.aws.amazon.com/saml"),
-      ).toBe("https://signin.aws.amazon.com/saml");
-    });
-
-    it("should preserve known shared Microsoft login paths", () => {
-      expect(
-        login._redactUrlForDebug(
-          "https://login.microsoftonline.com/common/GetCredentialType?mkt=en",
-        ),
-      ).toBe(
-        "https://login.microsoftonline.com/common/GetCredentialType?mkt=%5Bredacted%5D",
-      );
-    });
-  });
-
   describe("_redactArnForDebug", () => {
     it("should redact the account id and resource name in IAM ARNs", () => {
       expect(

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -1459,8 +1459,8 @@ describe("login", () => {
         )
         .catch((e: unknown) => e);
       expect(error).toBeInstanceOf(CLIError);
-      expect((error as CLIError).message).toContain(
-        "was not found in the SAML response",
+      expect((error as CLIError).message).toBe(
+        "Configured default role ARN was not found in the SAML response.",
       );
     });
   });
@@ -3173,6 +3173,38 @@ describe("login", () => {
       expect(mockPage.screenshot).toHaveBeenCalledWith({
         path: "az2aws-unrecognized-state.png",
       });
+    });
+
+    it("should avoid screenshots in shared environments when unrecognized page persists", async () => {
+      const mockPage = createMockPage();
+      const mockBrowser = createMockBrowser(mockPage);
+      mockPuppeteerLaunch.mockResolvedValue(mockBrowser);
+      mockPage.$.mockResolvedValue(null);
+
+      const error = await login
+        ._performLoginAsync(
+          "https://login.example.com",
+          true,
+          false,
+          true,
+          false,
+          false,
+          "",
+          undefined,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+        )
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(CLIError);
+      expect((error as CLIError).message).toBe(
+        "Unable to recognize page state in a shared environment. Re-run locally with --mode=debug to capture a screenshot.",
+      );
+      expect(mockPage.screenshot).not.toHaveBeenCalled();
     });
 
     it("should continue loop when page.$ throws an error", async () => {

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -171,13 +171,13 @@ describe("login", () => {
   });
 
   describe("_redactUrlForDebug", () => {
-    it("should redact query parameter values from URLs", () => {
+    it("should redact tenant path segments and query parameter values from login URLs", () => {
       expect(
         login._redactUrlForDebug(
           "https://login.microsoftonline.com/tenant/saml2?SAMLRequest=abc123&foo=bar",
         ),
       ).toBe(
-        "https://login.microsoftonline.com/tenant/saml2?SAMLRequest=%5Bredacted%5D&foo=%5Bredacted%5D",
+        "https://login.microsoftonline.com/[redacted]/saml2?SAMLRequest=%5Bredacted%5D&foo=%5Bredacted%5D",
       );
     });
 
@@ -186,13 +186,23 @@ describe("login", () => {
         login._redactUrlForDebug("https://signin.aws.amazon.com/saml"),
       ).toBe("https://signin.aws.amazon.com/saml");
     });
+
+    it("should preserve known shared Microsoft login paths", () => {
+      expect(
+        login._redactUrlForDebug(
+          "https://login.microsoftonline.com/common/GetCredentialType?mkt=en",
+        ),
+      ).toBe(
+        "https://login.microsoftonline.com/common/GetCredentialType?mkt=%5Bredacted%5D",
+      );
+    });
   });
 
   describe("_redactArnForDebug", () => {
-    it("should redact the account id in IAM ARNs", () => {
+    it("should redact the account id and resource name in IAM ARNs", () => {
       expect(
         login._redactArnForDebug("arn:aws:iam::123456789012:role/TestRole"),
-      ).toBe("arn:aws:iam::[redacted]:role/TestRole");
+      ).toBe("arn:aws:iam::[redacted]:role/[redacted]");
     });
 
     it("should leave non-IAM ARNs unchanged", () => {

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -148,6 +148,60 @@ describe("login", () => {
     });
   });
 
+  describe("_redactProfileForDebug", () => {
+    it("should redact sensitive profile fields while keeping duration visible", () => {
+      expect(
+        login._redactProfileForDebug({
+          azure_tenant_id: "tenant-id",
+          azure_app_id_uri: "https://signin.aws.amazon.com/saml#app",
+          azure_default_username: "user@example.com",
+          azure_default_password: "secret",
+          azure_default_role_arn: "arn:aws:iam::123456789012:role/Test",
+          azure_default_duration_hours: "8",
+        }),
+      ).toEqual({
+        azure_tenant_id: "[redacted]",
+        azure_app_id_uri: "[redacted]",
+        azure_default_username: "[redacted]",
+        azure_default_password: "[redacted]",
+        azure_default_role_arn: "[redacted]",
+        azure_default_duration_hours: "8",
+      });
+    });
+  });
+
+  describe("_redactUrlForDebug", () => {
+    it("should redact query parameter values from URLs", () => {
+      expect(
+        login._redactUrlForDebug(
+          "https://login.microsoftonline.com/tenant/saml2?SAMLRequest=abc123&foo=bar",
+        ),
+      ).toBe(
+        "https://login.microsoftonline.com/tenant/saml2?SAMLRequest=%5Bredacted%5D&foo=%5Bredacted%5D",
+      );
+    });
+
+    it("should leave URLs without query parameters unchanged", () => {
+      expect(
+        login._redactUrlForDebug("https://signin.aws.amazon.com/saml"),
+      ).toBe("https://signin.aws.amazon.com/saml");
+    });
+  });
+
+  describe("_redactArnForDebug", () => {
+    it("should redact the account id in IAM ARNs", () => {
+      expect(
+        login._redactArnForDebug("arn:aws:iam::123456789012:role/TestRole"),
+      ).toBe("arn:aws:iam::[redacted]:role/TestRole");
+    });
+
+    it("should leave non-IAM ARNs unchanged", () => {
+      expect(login._redactArnForDebug("arn:aws:s3:::example-bucket")).toBe(
+        "arn:aws:s3:::example-bucket",
+      );
+    });
+  });
+
   describe("_parseRolesFromSamlResponse", () => {
     it("should parse a single role from SAML response", () => {
       const samlAssertion = Buffer.from(

--- a/src/login.ts
+++ b/src/login.ts
@@ -20,7 +20,11 @@ import {
   sessionDurationHoursValidationMessage,
   validateSessionDurationHours,
 } from "./sessionDuration";
-import { formatDebugErrorMessage, redactUrlForLogs } from "./sensitiveOutput";
+import {
+  formatDebugErrorMessage,
+  redactUrlForLogs,
+  shouldAllowSensitiveOutput,
+} from "./sensitiveOutput";
 
 const debug = _debug("az2aws");
 
@@ -145,6 +149,7 @@ export const login = {
         profile.azure_tenant_id,
         assertionConsumerServiceURL,
       );
+      const allowSensitiveOutput = shouldAllowSensitiveOutput();
       const samlResponse = await this._performLoginAsync(
         loginUrl,
         headless,
@@ -159,7 +164,7 @@ export const login = {
         noDisableExtensions,
         disableGpu,
         incognito,
-        !credentialProcess,
+        allowSensitiveOutput,
       );
       const roles = this._parseRolesFromSamlResponse(samlResponse);
       const { role, durationHours } =

--- a/src/login.ts
+++ b/src/login.ts
@@ -33,6 +33,7 @@ const AZURE_AD_SSO = "autologon.microsoftazuread-sso.com";
 const AWS_SAML_ENDPOINT = "https://signin.aws.amazon.com/saml";
 const AWS_CN_SAML_ENDPOINT = "https://signin.amazonaws.cn/saml";
 const AWS_GOV_SAML_ENDPOINT = "https://signin.amazonaws-us-gov.com/saml";
+const REDACTED = "[redacted]";
 
 // Keep the runtime import as native `import()` so CommonJS output can load
 // the ESM-only https-proxy-agent package.
@@ -261,11 +262,42 @@ export const login = {
       }
     }
     debug("Environment");
-    debug({
-      ...env,
-      azure_default_password: "xxxxxxxxxx",
-    });
+    debug(this._redactProfileForDebug(env));
     return env;
+  },
+
+  _redactProfileForDebug(env: { [key: string]: string }): {
+    [key: string]: string;
+  } {
+    return Object.fromEntries(
+      Object.entries(env).map(([key, value]) => [
+        key,
+        key === "azure_default_duration_hours" ? value : REDACTED,
+      ]),
+    );
+  },
+
+  _redactUrlForDebug(url: string): string {
+    try {
+      const parsedUrl = new URL(url);
+
+      for (const key of new Set(parsedUrl.searchParams.keys())) {
+        parsedUrl.searchParams.set(key, REDACTED);
+      }
+
+      return parsedUrl.toString();
+    } catch {
+      const questionMarkIndex = url.indexOf("?");
+      if (questionMarkIndex === -1) {
+        return url;
+      }
+
+      return `${url.slice(0, questionMarkIndex)}?${REDACTED}`;
+    }
+  },
+
+  _redactArnForDebug(arn: string): string {
+    return arn.replace(/(arn:[^:]+:iam::)([^:]+)(:.*)/, `$1${REDACTED}$3`);
   },
 
   // Load the profile
@@ -315,7 +347,7 @@ export const login = {
             <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"></samlp:NameIDPolicy>
         </samlp:AuthnRequest>
         `;
-    debug("Generated SAML request", samlRequest);
+    debug("Generated SAML request");
 
     debug("Deflating SAML");
 
@@ -331,7 +363,7 @@ export const login = {
         const url = `https://login.microsoftonline.com/${tenantId}/saml2?SAMLRequest=${encodeURIComponent(
           samlBase64,
         )}`;
-        debug("Created login URL", url);
+        debug("Created login URL", this._redactUrlForDebug(url));
 
         return resolve(url);
       });
@@ -490,7 +522,7 @@ export const login = {
       const samlResponsePromise = new Promise((resolve) => {
         page.on("request", (req: HTTPRequest) => {
           const reqURL = req.url();
-          debug(`Request: ${reqURL}`);
+          debug(`Request: ${this._redactUrlForDebug(reqURL)}`);
           if (
             reqURL === AWS_SAML_ENDPOINT ||
             reqURL === AWS_GOV_SAML_ENDPOINT ||
@@ -617,13 +649,15 @@ export const login = {
 
       const samlResponse = querystring.parse(samlResponseData).SAMLResponse;
 
-      debug("Found SAML response", samlResponse);
-
       if (!samlResponse) {
         throw new Error("SAML response not found");
       } else if (Array.isArray(samlResponse)) {
         throw new Error("SAML can't be an array");
       }
+
+      debug("Found SAML response", {
+        base64Length: samlResponse.length,
+      });
 
       return samlResponse;
     } finally {
@@ -642,7 +676,9 @@ export const login = {
   _parseRolesFromSamlResponse(assertion: string): Role[] {
     debug("Converting assertion from base64 to UTF-8");
     const samlText = Buffer.from(assertion, "base64").toString("utf8");
-    debug("Converted", samlText);
+    debug("Converted assertion from base64 to UTF-8", {
+      xmlLength: samlText.length,
+    });
 
     debug("Parsing SAML XML");
     const saml = load(samlText, { xmlMode: true });
@@ -664,7 +700,13 @@ export const login = {
       const principalArn = parts[principalIdx].trim();
       return { roleArn, principalArn };
     });
-    debug("Found roles", roles);
+    debug(
+      "Found roles",
+      roles.map((role) => ({
+        roleArn: this._redactArnForDebug(role.roleArn),
+        principalArn: this._redactArnForDebug(role.principalArn),
+      })),
+    );
     return roles;
   },
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -284,10 +284,6 @@ export const login = {
     );
   },
 
-  _redactUrlForDebug(url: string): string {
-    return redactUrlForLogs(url);
-  },
-
   _redactArnForDebug(arn: string): string {
     const match = arn.match(/^(arn:[^:]+:iam::)[^:]+:(.+?\/).+$/);
     if (!match) {
@@ -360,7 +356,7 @@ export const login = {
         const url = `https://login.microsoftonline.com/${tenantId}/saml2?SAMLRequest=${encodeURIComponent(
           samlBase64,
         )}`;
-        debug("Created login URL", this._redactUrlForDebug(url));
+        debug("Created login URL", redactUrlForLogs(url));
 
         return resolve(url);
       });
@@ -520,7 +516,7 @@ export const login = {
       const samlResponsePromise = new Promise((resolve) => {
         page.on("request", (req: HTTPRequest) => {
           const reqURL = req.url();
-          const redactedURL = this._redactUrlForDebug(reqURL);
+          const redactedURL = redactUrlForLogs(reqURL);
           debug(`Request: ${redactedURL}`);
           if (
             reqURL === AWS_SAML_ENDPOINT ||

--- a/src/login.ts
+++ b/src/login.ts
@@ -20,6 +20,7 @@ import {
   sessionDurationHoursValidationMessage,
   validateSessionDurationHours,
 } from "./sessionDuration";
+import { formatDebugErrorMessage, redactUrlForLogs } from "./sensitiveOutput";
 
 const debug = _debug("az2aws");
 
@@ -34,13 +35,6 @@ const AWS_SAML_ENDPOINT = "https://signin.aws.amazon.com/saml";
 const AWS_CN_SAML_ENDPOINT = "https://signin.amazonaws.cn/saml";
 const AWS_GOV_SAML_ENDPOINT = "https://signin.amazonaws-us-gov.com/saml";
 const REDACTED = "[redacted]";
-const SAFE_MICROSOFT_LOGIN_PATH_SEGMENTS = new Set([
-  "common",
-  "consumers",
-  "organizations",
-  "favicon.ico",
-  "kmsi",
-]);
 
 // Keep the runtime import as native `import()` so CommonJS output can load
 // the ESM-only https-proxy-agent package.
@@ -76,7 +70,7 @@ function handleBackgroundPromise(
   description: string,
 ): void {
   void promise.catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatDebugErrorMessage(error);
     debug(`${description}: ${message}`);
   });
 }
@@ -286,32 +280,7 @@ export const login = {
   },
 
   _redactUrlForDebug(url: string): string {
-    try {
-      const parsedUrl = new URL(url);
-      const pathSegments = parsedUrl.pathname.split("/");
-
-      if (
-        parsedUrl.hostname === "login.microsoftonline.com" &&
-        pathSegments[1] &&
-        !SAFE_MICROSOFT_LOGIN_PATH_SEGMENTS.has(pathSegments[1])
-      ) {
-        pathSegments[1] = REDACTED;
-        parsedUrl.pathname = pathSegments.join("/");
-      }
-
-      for (const key of new Set(parsedUrl.searchParams.keys())) {
-        parsedUrl.searchParams.set(key, REDACTED);
-      }
-
-      return parsedUrl.toString();
-    } catch {
-      const questionMarkIndex = url.indexOf("?");
-      if (questionMarkIndex === -1) {
-        return url;
-      }
-
-      return `${url.slice(0, questionMarkIndex)}?${REDACTED}`;
-    }
+    return redactUrlForLogs(url);
   },
 
   _redactArnForDebug(arn: string): string {
@@ -505,7 +474,7 @@ export const login = {
           !paths.userDataDir
         ) {
           debug(
-            `Browser launch failed with TargetCloseError. Resetting profile at ${paths.chromium}`,
+            "Browser launch failed with TargetCloseError. Resetting managed browser profile.",
           );
           console.warn(
             "Browser profile appears incompatible. Resetting profile data and retrying...",
@@ -561,7 +530,7 @@ export const login = {
                 headers: {},
                 body: "",
               }),
-              `Failed to respond to intercepted request ${reqURL}`,
+              "Failed to respond to intercepted request",
             );
             if (browser) {
               handleBackgroundPromise(
@@ -574,7 +543,7 @@ export const login = {
           } else {
             handleBackgroundPromise(
               req.continue(),
-              `Failed to continue intercepted request ${reqURL}`,
+              "Failed to continue intercepted request",
             );
           }
         });
@@ -595,7 +564,9 @@ export const login = {
         if (err instanceof Error) {
           // An error will be thrown if you're still logged in cause the page.goto ot waitForNavigation
           // will be a redirect to AWS. That's usually OK
-          debug(`Error occurred during loading the first page: ${err.message}`);
+          debug(
+            `Error occurred during loading the first page: ${formatDebugErrorMessage(err)}`,
+          );
         }
       }
 
@@ -618,7 +589,7 @@ export const login = {
                 debug(
                   `Error when running state "${
                     state.name
-                  }". ${err.toString()}. Retrying...`,
+                  }". ${formatDebugErrorMessage(err)}. Retrying...`,
                 );
               }
               break;
@@ -652,6 +623,12 @@ export const login = {
           } else {
             debug("State not recognized!");
             if (totalUnrecognizedDelay > MAX_UNRECOGNIZED_PAGE_DELAY) {
+              if (!allowSensitiveStateOutput) {
+                throw new CLIError(
+                  "Unable to recognize page state in a shared environment. Re-run locally with --mode=debug to capture a screenshot.",
+                );
+              }
+
               const path = "az2aws-unrecognized-state.png";
               await page.screenshot({ path });
               throw new CLIError(
@@ -775,7 +752,7 @@ export const login = {
         role = roles.find((r) => r.roleArn === defaultRoleArn);
         if (!role) {
           throw new CLIError(
-            `Default role ARN '${defaultRoleArn}' was not found in the SAML response.`,
+            "Configured default role ARN was not found in the SAML response.",
           );
         }
         debug("Valid role found. No need to ask.");

--- a/src/login.ts
+++ b/src/login.ts
@@ -34,6 +34,13 @@ const AWS_SAML_ENDPOINT = "https://signin.aws.amazon.com/saml";
 const AWS_CN_SAML_ENDPOINT = "https://signin.amazonaws.cn/saml";
 const AWS_GOV_SAML_ENDPOINT = "https://signin.amazonaws-us-gov.com/saml";
 const REDACTED = "[redacted]";
+const SAFE_MICROSOFT_LOGIN_PATH_SEGMENTS = new Set([
+  "common",
+  "consumers",
+  "organizations",
+  "favicon.ico",
+  "kmsi",
+]);
 
 // Keep the runtime import as native `import()` so CommonJS output can load
 // the ESM-only https-proxy-agent package.
@@ -158,6 +165,7 @@ export const login = {
         noDisableExtensions,
         disableGpu,
         incognito,
+        !credentialProcess,
       );
       const roles = this._parseRolesFromSamlResponse(samlResponse);
       const { role, durationHours } =
@@ -280,6 +288,16 @@ export const login = {
   _redactUrlForDebug(url: string): string {
     try {
       const parsedUrl = new URL(url);
+      const pathSegments = parsedUrl.pathname.split("/");
+
+      if (
+        parsedUrl.hostname === "login.microsoftonline.com" &&
+        pathSegments[1] &&
+        !SAFE_MICROSOFT_LOGIN_PATH_SEGMENTS.has(pathSegments[1])
+      ) {
+        pathSegments[1] = REDACTED;
+        parsedUrl.pathname = pathSegments.join("/");
+      }
 
       for (const key of new Set(parsedUrl.searchParams.keys())) {
         parsedUrl.searchParams.set(key, REDACTED);
@@ -297,7 +315,12 @@ export const login = {
   },
 
   _redactArnForDebug(arn: string): string {
-    return arn.replace(/(arn:[^:]+:iam::)([^:]+)(:.*)/, `$1${REDACTED}$3`);
+    const match = arn.match(/^(arn:[^:]+:iam::)[^:]+:(.+?\/).+$/);
+    if (!match) {
+      return arn;
+    }
+
+    return `${match[1]}${REDACTED}:${match[2]}${REDACTED}`;
   },
 
   // Load the profile
@@ -402,6 +425,7 @@ export const login = {
     noDisableExtensions: boolean,
     disableGpu: boolean,
     incognito = false,
+    allowSensitiveStateOutput = true,
   ): Promise<string> {
     debug("Loading login page in Chrome");
 
@@ -613,6 +637,7 @@ export const login = {
                   defaultUsername,
                   defaultPassword,
                   useRememberMe,
+                  allowSensitiveStateOutput,
                 ),
               ]);
 
@@ -831,7 +856,7 @@ export const login = {
     region: string,
     writeProfile = true,
   ): Promise<AwsCredentials | undefined> {
-    console.log(`Assuming role ${role.roleArn} in region ${region}...`);
+    console.log(`Assuming selected role in region ${region}...`);
     let stsOptions: STSClientConfig = {};
 
     if (awsNoVerifySsl) {

--- a/src/login.ts
+++ b/src/login.ts
@@ -520,7 +520,8 @@ export const login = {
       const samlResponsePromise = new Promise((resolve) => {
         page.on("request", (req: HTTPRequest) => {
           const reqURL = req.url();
-          debug(`Request: ${this._redactUrlForDebug(reqURL)}`);
+          const redactedURL = this._redactUrlForDebug(reqURL);
+          debug(`Request: ${redactedURL}`);
           if (
             reqURL === AWS_SAML_ENDPOINT ||
             reqURL === AWS_GOV_SAML_ENDPOINT ||
@@ -535,7 +536,7 @@ export const login = {
                 headers: {},
                 body: "",
               }),
-              "Failed to respond to intercepted request",
+              `Failed to respond to intercepted request ${redactedURL}`,
             );
             if (browser) {
               handleBackgroundPromise(
@@ -548,7 +549,7 @@ export const login = {
           } else {
             handleBackgroundPromise(
               req.continue(),
-              "Failed to continue intercepted request",
+              `Failed to continue intercepted request ${redactedURL}`,
             );
           }
         });

--- a/src/loginStates.test.ts
+++ b/src/loginStates.test.ts
@@ -146,6 +146,31 @@ describe("loginStates", () => {
       consoleSpy.mockRestore();
     });
 
+    it("should suppress error message output when sensitive output is disabled", async () => {
+      const mockPage = createMockPage();
+      const mockError = {};
+      mockPage.$.mockResolvedValue(mockError);
+      mockPage.evaluate.mockResolvedValue("Error message");
+      vi.mocked(inquirer.prompt).mockResolvedValue({
+        username: "user@example.com",
+      });
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await getUsernameState().handler(
+        mockPage as never,
+        createMockElementHandle() as never,
+        false,
+        "",
+        undefined,
+        false,
+        false,
+      );
+
+      expect(consoleSpy).not.toHaveBeenCalledWith("Error message");
+      consoleSpy.mockRestore();
+    });
+
     it("should wait for input, focus, clear, type, and submit", async () => {
       const mockPage = createMockPage();
       mockPage.$.mockResolvedValue(null);
@@ -562,6 +587,42 @@ describe("loginStates", () => {
 
       consoleSpy.mockRestore();
     });
+
+    it("should suppress passwordless instructions and auth code when sensitive output is disabled", async () => {
+      const mockPage = createMockPage();
+      const mockMessageElement = {};
+      const mockCodeElement = {};
+
+      mockPage.$.mockImplementation((selector: string) => {
+        if (selector === "#idDiv_RemoteNGC_PollingDescription")
+          return Promise.resolve(mockMessageElement);
+        if (selector === "#idRemoteNGC_DisplaySign")
+          return Promise.resolve(mockCodeElement);
+        return Promise.resolve(null);
+      });
+
+      mockPage.evaluate.mockImplementation((_fn: unknown, el: unknown) => {
+        if (el === mockMessageElement)
+          return Promise.resolve("Approve the sign-in request");
+        if (el === mockCodeElement) return Promise.resolve("42");
+        return Promise.resolve("");
+      });
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await getPasswordlessState().handler(
+        mockPage as never,
+        createMockElementHandle() as never,
+        false,
+        "",
+        undefined,
+        false,
+        false,
+      );
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
   });
 
   describe("TFA instructions handler", () => {
@@ -744,6 +805,30 @@ describe("loginStates", () => {
       );
 
       expect(consoleSpy).toHaveBeenCalledWith("Invalid code");
+      consoleSpy.mockRestore();
+    });
+
+    it("should suppress TFA code guidance when sensitive output is disabled", async () => {
+      const mockPage = createMockPage();
+      mockPage.$.mockResolvedValue(null);
+      mockPage.evaluate.mockResolvedValue("Enter the code shown in your app");
+      vi.mocked(inquirer.prompt).mockResolvedValue({
+        verificationCode: "654321",
+      });
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await getTfaCodeInputState().handler(
+        mockPage as never,
+        createMockElementHandle() as never,
+        false,
+        "",
+        undefined,
+        false,
+        false,
+      );
+
+      expect(consoleSpy).not.toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
 

--- a/src/loginStates.test.ts
+++ b/src/loginStates.test.ts
@@ -728,6 +728,30 @@ describe("loginStates", () => {
         "Authentication failed. Please try again.",
       );
     });
+
+    it("should throw sanitized CLIError when sensitive output is disabled", async () => {
+      const mockPage = createMockPage();
+      const mockElement = {};
+      mockPage.evaluate.mockResolvedValue(
+        "Authentication failed. Please try again.",
+      );
+
+      const error = await getTfaFailedState()
+        .handler(
+          mockPage as never,
+          mockElement as never,
+          false,
+          "",
+          undefined,
+          false,
+          false,
+        )
+        .catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CLIError);
+      expect((error as CLIError).message).toBe(
+        "Authentication failed during MFA challenge.",
+      );
+    });
   });
 
   describe("Service exception handler", () => {
@@ -752,6 +776,28 @@ describe("loginStates", () => {
       expect(error).toBeInstanceOf(CLIError);
       expect((error as CLIError).message).toBe(
         "Service temporarily unavailable",
+      );
+    });
+
+    it("should throw sanitized CLIError when sensitive output is disabled", async () => {
+      const mockPage = createMockPage();
+      const mockElement = {};
+      mockPage.evaluate.mockResolvedValue("Service temporarily unavailable");
+
+      const error = await getServiceExceptionState()
+        .handler(
+          mockPage as never,
+          mockElement as never,
+          false,
+          "",
+          undefined,
+          false,
+          false,
+        )
+        .catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CLIError);
+      expect((error as CLIError).message).toBe(
+        "Login provider returned a service exception.",
       );
     });
   });

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -13,6 +13,7 @@ export type StateHandler = (
   defaultUsername: string,
   defaultPassword: string | undefined,
   rememberMe: boolean,
+  allowSensitiveOutput: boolean,
 ) => Promise<void>;
 
 export interface State {
@@ -40,6 +41,12 @@ async function readTextContent<T extends Node>(
 const PASSWORD_SELECTOR =
   'input[name="Password"]:not(.moveOffScreen),input[name="passwd"]:not(.moveOffScreen)';
 
+function printPageMessage(message: string, allowSensitiveOutput = true): void {
+  if (allowSensitiveOutput) {
+    console.log(message);
+  }
+}
+
 /**
  * To proxy the input/output of the Azure login page, it's easiest to run a loop that
  * monitors the state of the page and then perform the corresponding CLI behavior.
@@ -56,12 +63,15 @@ export const states: State[] = [
       _selected: ElementHandle,
       noPrompt: boolean,
       defaultUsername: string,
+      _defaultPassword: string | undefined,
+      _rememberMe: boolean,
+      allowSensitiveOutput: boolean,
     ): Promise<void> {
       const error = await page.$(".alert-error");
       if (error) {
         debug("Found error message. Displaying");
         const errorMessage = await readTextContent(page, error);
-        console.log(errorMessage);
+        printPageMessage(errorMessage, allowSensitiveOutput);
       }
 
       let username: string;
@@ -135,6 +145,10 @@ export const states: State[] = [
       page: Page,
       _selected: ElementHandle,
       noPrompt: boolean,
+      _defaultUsername: string,
+      _defaultPassword: string | undefined,
+      _rememberMe: boolean,
+      allowSensitiveOutput: boolean,
     ): Promise<void> {
       debug("Multiple accounts associated with username.");
       const aadTile = await page.$("#aadTileTitle");
@@ -160,8 +174,9 @@ export const states: State[] = [
         });
       } else {
         debug("Asking user to choose account");
-        console.log(
+        printPageMessage(
           "It looks like this Username is used with more than one account from Microsoft. Which one do you want to use?",
+          allowSensitiveOutput,
         );
         const { account: selectedAccount } = await inquirer.prompt<{
           account: string;
@@ -192,7 +207,15 @@ export const states: State[] = [
   {
     name: "passwordless",
     selector: `input[value='Send notification']`,
-    async handler(page: Page) {
+    async handler(
+      page: Page,
+      _selected: ElementHandle,
+      _noPrompt: boolean,
+      _defaultUsername: string,
+      _defaultPassword: string | undefined,
+      _rememberMe: boolean,
+      allowSensitiveOutput: boolean,
+    ) {
       debug("Sending notification");
       await page.click("input[value='Send notification']");
       debug("Waiting for auth code");
@@ -206,10 +229,10 @@ export const states: State[] = [
       );
       const codeElement = await page.$("#idRemoteNGC_DisplaySign");
       const message = await readTextContent(page, messageElement);
-      console.log(message);
+      printPageMessage(message, allowSensitiveOutput);
       debug("Printing the auth code");
       const authCode = await readTextContent(page, codeElement);
-      console.log(authCode);
+      printPageMessage(authCode, allowSensitiveOutput);
       debug("Waiting for response");
       await page.waitForSelector(`#idRemoteNGC_DisplaySign`, {
         hidden: true,
@@ -226,12 +249,14 @@ export const states: State[] = [
       noPrompt: boolean,
       _defaultUsername: string,
       defaultPassword: string | undefined,
+      _rememberMe: boolean,
+      allowSensitiveOutput: boolean,
     ): Promise<void> {
       const error = await page.$(".alert-error");
       if (error) {
         debug("Found error message. Displaying");
         const errorMessage = await readTextContent(page, error);
-        console.log(errorMessage);
+        printPageMessage(errorMessage, allowSensitiveOutput);
         defaultPassword = ""; // Password error. Unset the default and allow user to enter it.
       }
 
@@ -273,9 +298,17 @@ export const states: State[] = [
   {
     name: "TFA instructions",
     selector: `#idDiv_SAOTCAS_Description`,
-    async handler(page: Page, selected: ElementHandle): Promise<void> {
+    async handler(
+      page: Page,
+      selected: ElementHandle,
+      _noPrompt: boolean,
+      _defaultUsername: string,
+      _defaultPassword: string | undefined,
+      _rememberMe: boolean,
+      allowSensitiveOutput: boolean,
+    ): Promise<void> {
       const descriptionMessage = await readTextContent(page, selected);
-      console.log(descriptionMessage);
+      printPageMessage(descriptionMessage, allowSensitiveOutput);
 
       try {
         debug("Waiting for authentication code to be displayed");
@@ -293,7 +326,7 @@ export const states: State[] = [
           authenticationCodeElement,
         );
         debug("Printing the authentication code to console");
-        console.log(authenticationCode);
+        printPageMessage(authenticationCode, allowSensitiveOutput);
       } catch {
         debug("No authentication code found on page");
       }
@@ -316,16 +349,24 @@ export const states: State[] = [
   {
     name: "TFA code input",
     selector: "input[name=otc]:not(.moveOffScreen)",
-    async handler(page: Page): Promise<void> {
+    async handler(
+      page: Page,
+      _selected: ElementHandle,
+      _noPrompt: boolean,
+      _defaultUsername: string,
+      _defaultPassword: string | undefined,
+      _rememberMe: boolean,
+      allowSensitiveOutput: boolean,
+    ): Promise<void> {
       const error = await page.$(".alert-error");
       if (error) {
         debug("Found error message. Displaying");
         const errorMessage = await readTextContent(page, error);
-        console.log(errorMessage);
+        printPageMessage(errorMessage, allowSensitiveOutput);
       } else {
         const description = await page.$("#idDiv_SAOTCC_Description");
         const descriptionMessage = await readTextContent(page, description);
-        console.log(descriptionMessage);
+        printPageMessage(descriptionMessage, allowSensitiveOutput);
       }
 
       const { verificationCode } = await inquirer.prompt<{

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -47,6 +47,14 @@ function printPageMessage(message: string, allowSensitiveOutput = true): void {
   }
 }
 
+function createSensitiveCliError(
+  message: string,
+  sanitizedMessage: string,
+  allowSensitiveOutput = true,
+): CLIError {
+  return new CLIError(allowSensitiveOutput ? message : sanitizedMessage);
+}
+
 /**
  * To proxy the input/output of the Azure login page, it's easiest to run a loop that
  * monitors the state of the page and then perform the corresponding CLI behavior.
@@ -341,9 +349,21 @@ export const states: State[] = [
   {
     name: "TFA failed",
     selector: `#idDiv_SAASDS_Description,#idDiv_SAASTO_Description`,
-    async handler(page: Page, selected: ElementHandle): Promise<void> {
+    async handler(
+      page: Page,
+      selected: ElementHandle,
+      _noPrompt: boolean,
+      _defaultUsername: string,
+      _defaultPassword: string | undefined,
+      _rememberMe: boolean,
+      allowSensitiveOutput: boolean,
+    ): Promise<void> {
       const descriptionMessage = await readTextContent(page, selected);
-      throw new CLIError(descriptionMessage);
+      throw createSensitiveCliError(
+        descriptionMessage,
+        "Authentication failed during MFA challenge.",
+        allowSensitiveOutput,
+      );
     },
   },
   {
@@ -436,9 +456,21 @@ export const states: State[] = [
   {
     name: "Service exception",
     selector: "#service_exception_message",
-    async handler(page: Page, selected: ElementHandle): Promise<void> {
+    async handler(
+      page: Page,
+      selected: ElementHandle,
+      _noPrompt: boolean,
+      _defaultUsername: string,
+      _defaultPassword: string | undefined,
+      _rememberMe: boolean,
+      allowSensitiveOutput: boolean,
+    ): Promise<void> {
       const descriptionMessage = await readTextContent(page, selected);
-      throw new CLIError(descriptionMessage);
+      throw createSensitiveCliError(
+        descriptionMessage,
+        "Login provider returned a service exception.",
+        allowSensitiveOutput,
+      );
     },
   },
 ];

--- a/src/sensitiveOutput.test.ts
+++ b/src/sensitiveOutput.test.ts
@@ -4,6 +4,7 @@ import {
   formatUnexpectedErrorMessage,
   redactUrlForLogs,
   sanitizeMessage,
+  shouldAllowSensitiveOutput,
 } from "./sensitiveOutput";
 
 describe("sensitiveOutput", () => {
@@ -48,13 +49,40 @@ describe("sensitiveOutput", () => {
     );
   });
 
-  it("replaces unexpected errors with a generic message in shared environments", () => {
+  it("sanitizes unexpected error messages in shared environments", () => {
     expect(
-      formatUnexpectedErrorMessage(new Error("SAMLResponse=secret-value"), {
-        GITHUB_ACTIONS: "true",
-      }),
+      formatUnexpectedErrorMessage(
+        new Error(
+          "Navigation failed: https://login.microsoftonline.com/tenant/saml2?SAMLRequest=secret",
+        ),
+        { GITHUB_ACTIONS: "true" },
+      ),
     ).toBe(
-      "az2aws failed with an unexpected error in a shared environment. Re-run locally with DEBUG=az2aws for full details.",
+      "Navigation failed: https://login.microsoftonline.com/[redacted]/saml2?SAMLRequest=%5Bredacted%5D",
     );
+  });
+
+  it("returns raw unexpected error message locally", () => {
+    expect(
+      formatUnexpectedErrorMessage(new Error("SAMLResponse=secret-value"), {}),
+    ).toBe("SAMLResponse=secret-value");
+  });
+
+  describe("shouldAllowSensitiveOutput", () => {
+    it("allows sensitive output when no CI variables are set", () => {
+      expect(shouldAllowSensitiveOutput({})).toBe(true);
+    });
+
+    it("disallows sensitive output when CI is set to any truthy value", () => {
+      expect(shouldAllowSensitiveOutput({ CI: "1" })).toBe(false);
+      expect(shouldAllowSensitiveOutput({ CI: "true" })).toBe(false);
+      expect(shouldAllowSensitiveOutput({ CI: "yes" })).toBe(false);
+    });
+
+    it("disallows sensitive output when GITHUB_ACTIONS is set", () => {
+      expect(shouldAllowSensitiveOutput({ GITHUB_ACTIONS: "true" })).toBe(
+        false,
+      );
+    });
   });
 });

--- a/src/sensitiveOutput.test.ts
+++ b/src/sensitiveOutput.test.ts
@@ -22,8 +22,18 @@ describe("sensitiveOutput", () => {
       sanitizeMessage(
         'AccessKeyId=AKIAIOSFODNN7EXAMPLE SecretAccessKey="top-secret" SessionToken=session-token',
       ),
-    ).toBe(
-      "AccessKeyId=[redacted] SecretAccessKey=[redacted] SessionToken=[redacted]",
+    ).toBe("AccessKeyId=[redacted]");
+  });
+
+  it("redacts spaced header values like Authorization Bearer tokens", () => {
+    expect(sanitizeMessage("Authorization: Bearer abc123xyz")).toBe(
+      "Authorization: [redacted]",
+    );
+  });
+
+  it("redacts full Cookie header value including multiple pairs", () => {
+    expect(sanitizeMessage("Cookie: session=abc; token=xyz")).toBe(
+      "Cookie: [redacted]",
     );
   });
 

--- a/src/sensitiveOutput.test.ts
+++ b/src/sensitiveOutput.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCliErrorMessage,
+  formatUnexpectedErrorMessage,
+  redactUrlForLogs,
+  sanitizeMessage,
+} from "./sensitiveOutput";
+
+describe("sensitiveOutput", () => {
+  it("redacts credentials and query parameters from URLs", () => {
+    expect(
+      redactUrlForLogs(
+        "https://user:pass@login.microsoftonline.com/tenant/saml2?SAMLRequest=abc123&foo=bar#hash",
+      ),
+    ).toBe(
+      "https://%5Bredacted%5D:%5Bredacted%5D@login.microsoftonline.com/[redacted]/saml2?SAMLRequest=%5Bredacted%5D&foo=%5Bredacted%5D#[redacted]",
+    );
+  });
+
+  it("redacts well-known secret fields from free-form messages", () => {
+    expect(
+      sanitizeMessage(
+        'AccessKeyId=AKIAIOSFODNN7EXAMPLE SecretAccessKey="top-secret" SessionToken=session-token',
+      ),
+    ).toBe(
+      "AccessKeyId=[redacted] SecretAccessKey=[redacted] SessionToken=[redacted]",
+    );
+  });
+
+  it("sanitizes CLI error messages in shared environments", () => {
+    expect(
+      formatCliErrorMessage(
+        "Request failed: https://login.microsoftonline.com/tenant/saml2?SAMLRequest=secret",
+        { CI: "true" },
+      ),
+    ).toBe(
+      "Request failed: https://login.microsoftonline.com/[redacted]/saml2?SAMLRequest=%5Bredacted%5D",
+    );
+  });
+
+  it("replaces unexpected errors with a generic message in shared environments", () => {
+    expect(
+      formatUnexpectedErrorMessage(new Error("SAMLResponse=secret-value"), {
+        GITHUB_ACTIONS: "true",
+      }),
+    ).toBe(
+      "az2aws failed with an unexpected error in a shared environment. Re-run locally with DEBUG=az2aws for full details.",
+    );
+  });
+});

--- a/src/sensitiveOutput.ts
+++ b/src/sensitiveOutput.ts
@@ -31,13 +31,11 @@ const SENSITIVE_JSON_PATTERN = new RegExp(
   `((?:"(?:${SENSITIVE_FIELD_NAMES.join("|")})"\\s*:\\s*))(?:"[^"]*"|null|[^\\s,}]+)`,
   "gi",
 );
-const SHARED_ENVIRONMENT_ERROR_MESSAGE =
-  "az2aws failed with an unexpected error in a shared environment. Re-run locally with DEBUG=az2aws for full details.";
 
 export function shouldAllowSensitiveOutput(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return env.CI !== "true" && env.GITHUB_ACTIONS !== "true";
+  return !env.CI && !env.GITHUB_ACTIONS;
 }
 
 export function redactUrlForLogs(url: string): string {
@@ -97,11 +95,8 @@ export function formatUnexpectedErrorMessage(
   error: unknown,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  if (shouldAllowSensitiveOutput(env)) {
-    return error instanceof Error ? error.message : String(error);
-  }
-
-  return SHARED_ENVIRONMENT_ERROR_MESSAGE;
+  const message = error instanceof Error ? error.message : String(error);
+  return shouldAllowSensitiveOutput(env) ? message : sanitizeMessage(message);
 }
 
 export function formatDebugErrorMessage(

--- a/src/sensitiveOutput.ts
+++ b/src/sensitiveOutput.ts
@@ -24,7 +24,7 @@ const SENSITIVE_FIELD_NAMES = [
   "Set-Cookie",
 ];
 const SENSITIVE_ASSIGNMENT_PATTERN = new RegExp(
-  `((?:${SENSITIVE_FIELD_NAMES.join("|")})\\s*[=:]\\s*)(?:"[^"]*"|'[^']*'|[^\\s,;]+)`,
+  `((?:${SENSITIVE_FIELD_NAMES.join("|")})\\s*[=:]\\s*)(?:"[^"]*"|'[^']*'|.+)`,
   "gi",
 );
 const SENSITIVE_JSON_PATTERN = new RegExp(

--- a/src/sensitiveOutput.ts
+++ b/src/sensitiveOutput.ts
@@ -1,0 +1,113 @@
+const REDACTED = "[redacted]";
+const SAFE_MICROSOFT_LOGIN_PATH_SEGMENTS = new Set([
+  "common",
+  "consumers",
+  "organizations",
+  "favicon.ico",
+  "kmsi",
+]);
+const URL_PATTERN = /\bhttps?:\/\/[^\s"'`<>]+/gi;
+const AWS_ACCESS_KEY_ID_PATTERN = /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g;
+const SENSITIVE_FIELD_NAMES = [
+  "AZURE_DEFAULT_PASSWORD",
+  "password",
+  "aws_access_key_id",
+  "aws_secret_access_key",
+  "aws_session_token",
+  "AccessKeyId",
+  "SecretAccessKey",
+  "SessionToken",
+  "SAMLAssertion",
+  "SAMLResponse",
+  "Authorization",
+  "Cookie",
+  "Set-Cookie",
+];
+const SENSITIVE_ASSIGNMENT_PATTERN = new RegExp(
+  `((?:${SENSITIVE_FIELD_NAMES.join("|")})\\s*[=:]\\s*)(?:"[^"]*"|'[^']*'|[^\\s,;]+)`,
+  "gi",
+);
+const SENSITIVE_JSON_PATTERN = new RegExp(
+  `((?:"(?:${SENSITIVE_FIELD_NAMES.join("|")})"\\s*:\\s*))(?:"[^"]*"|null|[^\\s,}]+)`,
+  "gi",
+);
+const SHARED_ENVIRONMENT_ERROR_MESSAGE =
+  "az2aws failed with an unexpected error in a shared environment. Re-run locally with DEBUG=az2aws for full details.";
+
+export function shouldAllowSensitiveOutput(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.CI !== "true" && env.GITHUB_ACTIONS !== "true";
+}
+
+export function redactUrlForLogs(url: string): string {
+  try {
+    const parsedUrl = new URL(url);
+    const pathSegments = parsedUrl.pathname.split("/");
+
+    if (
+      parsedUrl.hostname === "login.microsoftonline.com" &&
+      pathSegments[1] &&
+      !SAFE_MICROSOFT_LOGIN_PATH_SEGMENTS.has(pathSegments[1])
+    ) {
+      pathSegments[1] = REDACTED;
+      parsedUrl.pathname = pathSegments.join("/");
+    }
+
+    if (parsedUrl.username || parsedUrl.password) {
+      parsedUrl.username = REDACTED;
+      parsedUrl.password = REDACTED;
+    }
+
+    for (const key of new Set(parsedUrl.searchParams.keys())) {
+      parsedUrl.searchParams.set(key, REDACTED);
+    }
+
+    if (parsedUrl.hash) {
+      parsedUrl.hash = REDACTED;
+    }
+
+    return parsedUrl.toString();
+  } catch {
+    const questionMarkIndex = url.indexOf("?");
+    if (questionMarkIndex === -1) {
+      return url;
+    }
+
+    return `${url.slice(0, questionMarkIndex)}?${REDACTED}`;
+  }
+}
+
+export function sanitizeMessage(message: string): string {
+  return message
+    .replace(URL_PATTERN, (url) => redactUrlForLogs(url))
+    .replace(AWS_ACCESS_KEY_ID_PATTERN, REDACTED)
+    .replace(SENSITIVE_ASSIGNMENT_PATTERN, `$1${REDACTED}`)
+    .replace(SENSITIVE_JSON_PATTERN, `$1"${REDACTED}"`);
+}
+
+export function formatCliErrorMessage(
+  message: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return shouldAllowSensitiveOutput(env) ? message : sanitizeMessage(message);
+}
+
+export function formatUnexpectedErrorMessage(
+  error: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (shouldAllowSensitiveOutput(env)) {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  return SHARED_ENVIRONMENT_ERROR_MESSAGE;
+}
+
+export function formatDebugErrorMessage(
+  error: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return shouldAllowSensitiveOutput(env) ? message : sanitizeMessage(message);
+}

--- a/src/sensitiveOutput.ts
+++ b/src/sensitiveOutput.ts
@@ -103,6 +103,5 @@ export function formatDebugErrorMessage(
   error: unknown,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  const message = error instanceof Error ? error.message : String(error);
-  return shouldAllowSensitiveOutput(env) ? message : sanitizeMessage(message);
+  return formatUnexpectedErrorMessage(error, env);
 }

--- a/src/updateNotifier.test.ts
+++ b/src/updateNotifier.test.ts
@@ -37,6 +37,7 @@ describe("checkForUpdate", () => {
       throw new Error("ENOENT");
     });
     vi.mocked(fs.mkdirSync).mockImplementation(() => undefined as never);
+    vi.mocked(fs.chmodSync).mockImplementation(() => undefined as never);
     vi.mocked(fs.writeFileSync).mockImplementation(() => {});
   });
 
@@ -58,6 +59,17 @@ describe("checkForUpdate", () => {
     expect(message).toContain("1.5.0 -> 2.0.0");
     expect(message).toContain("npm install -g az2aws");
     expect(message).not.toContain("mise use -g npm:az2aws");
+    expect(fs.mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `${process.platform === "win32" ? "\\" : "/"}az2aws`,
+      ),
+      { recursive: true, mode: 0o700 },
+    );
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("update-check.json"),
+      expect.any(String),
+      { mode: 0o600 },
+    );
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 

--- a/src/updateNotifier.ts
+++ b/src/updateNotifier.ts
@@ -8,6 +8,8 @@ const CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
 const FAKE_LATEST_VERSION_ENV = "AZ2AWS_FAKE_LATEST_VERSION";
 const ANSI_YELLOW = "\u001b[33m";
 const ANSI_RESET = "\u001b[0m";
+const CONFIG_DIR_MODE = 0o700;
+const CACHE_FILE_MODE = 0o600;
 
 type InstallMethod = "mise" | "snap" | "unknown";
 
@@ -44,11 +46,18 @@ function writeCache(latestVersion: string): void {
   try {
     const cachePath = getCachePath();
     const dir = path.dirname(cachePath);
-    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(dir, { recursive: true, mode: CONFIG_DIR_MODE });
+    if (process.platform !== "win32") {
+      fs.chmodSync(dir, CONFIG_DIR_MODE);
+    }
     fs.writeFileSync(
       cachePath,
       JSON.stringify({ latestVersion, checkedAt: Date.now() }),
+      { mode: CACHE_FILE_MODE },
     );
+    if (process.platform !== "win32") {
+      fs.chmodSync(cachePath, CACHE_FILE_MODE);
+    }
   } catch {
     // Ignore cache write failures
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    exclude: ["src/**/*.e2e.test.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html", "lcov"],

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    disableConsoleIntercept: true,
     globals: true,
     environment: "node",
     include: ["src/**/*.e2e.test.ts"],

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.e2e.test.ts"],
+    coverage: {
+      enabled: false,
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add macos-latest to the main CI matrix while keeping coverage on ubuntu-slim
- split the live Azure->AWS browser smoke test into a dedicated pnpm test:e2e command and workflow job
- document the E2E environment variables and execution model for contributors

## Testing
- pnpm lint
- pnpm test
- pnpm build
- pnpm test:e2e (fails locally without the required AZ2AWS_E2E_* environment variables, which is expected)

Closes #181
