### PR TITLE
chore(ci): switch to Corepack and drop manual pnpm store cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,18 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
-          cache: pnpm
-      - run: corepack enable
+      - run: corepack enable pnpm
+        shell: bash
+      - name: Export pnpm store path
+        shell: bash
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7a6c8dd5c50e56e9e4e3b9147a0ac7a4e5 # v5.0.5
+        with:
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - if: matrix.os == 'ubuntu-slim'
@@ -74,8 +84,18 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
-          cache: pnpm
-      - run: corepack enable
+      - run: corepack enable pnpm
+        shell: bash
+      - name: Export pnpm store path
+        shell: bash
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7a6c8dd5c50e56e9e4e3b9147a0ac7a4e5 # v5.0.5
+        with:
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-
       - run: pnpm install --frozen-lockfile
       - name: Detect system Chrome
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
+      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - if: matrix.os == 'ubuntu-slim'
@@ -71,11 +71,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
+      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - name: Detect system Chrome
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,16 +34,6 @@ jobs:
           node-version: 24
       - run: corepack enable pnpm
         shell: bash
-      - name: Export pnpm store path
-        shell: bash
-        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-      - name: Cache pnpm store
-        uses: actions/cache@27d5ce7a6c8dd5c50e56e9e4e3b9147a0ac7a4e5 # v5.0.5
-        with:
-          path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - if: matrix.os == 'ubuntu-slim'
@@ -86,16 +76,6 @@ jobs:
           node-version: 24
       - run: corepack enable pnpm
         shell: bash
-      - name: Export pnpm store path
-        shell: bash
-        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-      - name: Cache pnpm store
-        uses: actions/cache@27d5ce7a6c8dd5c50e56e9e4e3b9147a0ac7a4e5 # v5.0.5
-        with:
-          path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-
       - run: pnpm install --frozen-lockfile
       - name: Detect system Chrome
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,6 @@ jobs:
           node-version: 24
       - run: corepack enable pnpm
         shell: bash
-      - name: Export pnpm store path
-        shell: bash
-        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-      - name: Cache pnpm store
-        uses: actions/cache@27d5ce7a6c8dd5c50e56e9e4e3b9147a0ac7a4e5 # v5.0.5
-        with:
-          path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,18 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
-          cache: pnpm
-      - run: corepack enable
+      - run: corepack enable pnpm
+        shell: bash
+      - name: Export pnpm store path
+        shell: bash
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7a6c8dd5c50e56e9e4e3b9147a0ac7a4e5 # v5.0.5
+        with:
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-node24-pnpm-store-
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
+      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test


### PR DESCRIPTION
## Summary
- Remove `pnpm/action-setup` from the main and release workflows and provision pnpm via `corepack enable pnpm` instead, using the version pinned by `packageManager` in `package.json`.
- Drop the manual `actions/cache` steps for the pnpm store; `actions/setup-node@v6` caches the store automatically based on the detected package manager.

## Notes
- `publish-npm` is unchanged (it uses `npm`, and already sets `package-manager-cache: false`).
- Inspired by https://zenn.dev/longrun_jp/articles/hello-corepack-goodbye-pnpm-action-setup
- Verified green on ubuntu-slim / macos-latest / windows-latest in the `Main` workflow of this PR. `e2e` and `release` are not exercised by PR events and will be validated on merge / next release.