### PR TITLE
fix(login): retry managed profile reset on Windows lock errors

### DIFF
--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -2623,6 +2623,8 @@ describe("login", () => {
       expect(mockFsRm).toHaveBeenCalledWith("/mock/chromium/path", {
         recursive: true,
         force: true,
+        maxRetries: 5,
+        retryDelay: 100,
       });
       expect(mockFsMkdir).toHaveBeenCalledTimes(2);
       expect(mockFsMkdir).toHaveBeenNthCalledWith(1, "/mock/chromium/path", {
@@ -2687,6 +2689,8 @@ describe("login", () => {
         {
           recursive: true,
           force: true,
+          maxRetries: 5,
+          retryDelay: 100,
         },
       );
       expect(mockFsMkdir).toHaveBeenCalledTimes(2);
@@ -2832,6 +2836,43 @@ describe("login", () => {
       expect(error).toBe(retryError);
       expect(mockFsRm).toHaveBeenCalled();
       expect(mockPuppeteerLaunch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should propagate fs.rm failure when Windows lock retries are exhausted", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (paths as any).userDataDir = undefined;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (paths as any).chromium = "C:\\Users\\alice\\.aws\\chromium";
+
+      mockPuppeteerLaunch.mockRejectedValueOnce(
+        new TargetCloseError("Protocol error: Target closed"),
+      );
+      const ebusy = Object.assign(new Error("EBUSY: resource busy or locked"), {
+        code: "EBUSY",
+      });
+      mockFsRm.mockRejectedValueOnce(ebusy);
+
+      const error = await login
+        ._performLoginAsync(
+          "https://login.example.com",
+          true,
+          false,
+          false,
+          false,
+          false,
+          "",
+          undefined,
+          false,
+          true, // rememberMe=true
+          false,
+          false,
+        )
+        .catch((e: unknown) => e);
+
+      expect(error).toBe(ebusy);
+      expect(mockFsRm).toHaveBeenCalledTimes(1);
+      // Retry should not have happened because the profile reset failed
+      expect(mockPuppeteerLaunch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -480,7 +480,12 @@ export const login = {
           console.warn(
             "Browser profile appears incompatible. Resetting profile data and retrying...",
           );
-          await fs.rm(paths.chromium, { recursive: true, force: true });
+          await fs.rm(paths.chromium, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 100,
+          });
           await fs.mkdir(paths.chromium, { recursive: true });
           browser = await puppeteer.launch(launchParams);
         } else {


### PR DESCRIPTION
## Summary
- Pass `maxRetries`/`retryDelay` to the `fs.rm` call that wipes the managed Chromium profile during `TargetCloseError` recovery, so Windows `EPERM`/`EBUSY` lock errors no longer abort the self-healing path.
- Add a regression test covering the exhausted-retry case and update the existing profile-reset tests to assert the new retry options.

Closes #175

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)