### PR TITLE
fix(update-notifier): shorten cache TTL to 6 hours

### DIFF
--- a/src/updateNotifier.test.ts
+++ b/src/updateNotifier.test.ts
@@ -141,7 +141,7 @@ describe("checkForUpdate", () => {
   it("should ignore expired cache and fetch fresh data", async () => {
     const expiredCache = JSON.stringify({
       latestVersion: "2.0.0",
-      checkedAt: Date.now() - 1000 * 60 * 60 * 25, // 25 hours ago
+      checkedAt: Date.now() - 1000 * 60 * 60 * 7, // 7 hours ago
     });
     vi.mocked(fs.readFileSync).mockReturnValue(expiredCache);
 

--- a/src/updateNotifier.ts
+++ b/src/updateNotifier.ts
@@ -4,7 +4,7 @@ import path from "path";
 import os from "os";
 
 const PACKAGE_NAME = "az2aws";
-const CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
+const CACHE_TTL_MS = 1000 * 60 * 60 * 6; // 6 hours
 const FAKE_LATEST_VERSION_ENV = "AZ2AWS_FAKE_LATEST_VERSION";
 const ANSI_YELLOW = "\u001b[33m";
 const ANSI_RESET = "\u001b[0m";


### PR DESCRIPTION
## Summary
- Reduce the update-notifier cache TTL from 24h to 6h so users see new release notifications sooner after a publish.
- Update the corresponding "expired cache" test to use a 7-hour-old cache so it stays meaningful under the new TTL.

## Motivation
The notifier cached the npm registry `latest` response for 24 hours. If a user ran `az2aws` shortly before a release, they wouldn't see the update notification until up to a day later. 6h keeps registry traffic negligible while making new releases surface within the same working day.

## Test plan
- [x] `npx vitest run src/updateNotifier.test.ts` (14 passed)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)