### PR TITLE
fix: MFA code display and password re-prompts caused by the bundled headless browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,18 @@ To avoid storing passwords in bash history, use a leading space:
     HISTCONTROL=ignoreboth
      export AZURE_DEFAULT_PASSWORD=mypassword
 
-#### Use an Existing Chrome Install and Profile
+#### Browser Selection
 
-Use your own Chrome installation by setting these environment variables:
+az2aws automatically uses your system Google Chrome (or Microsoft Edge) when
+one is installed, and falls back to the Chrome for Testing browser bundled
+with Puppeteer when no system browser is found or it fails to launch. Using
+a real browser matters because Microsoft Entra ID may treat the bundled
+automation browser as untrusted — for example refusing to reuse "Stay logged
+in" sessions. Firefox is not supported. Auto-detection is skipped in CI
+environments.
 
-- `BROWSER_CHROME_BIN` - Path to Chrome executable
+- `BROWSER_USE_SYSTEM_CHROME=0` - Always use the bundled browser
+- `BROWSER_CHROME_BIN` - Explicit path to a Chromium-based browser (overrides auto-detection)
 - `BROWSER_USER_DATA_DIR` - Chrome user data directory
 - `BROWSER_PROFILE_DIR` - Chrome profile name (e.g., "Default")
 
@@ -301,17 +308,12 @@ If you are prompted for your password on every login even though "Stay logged
 in" (`azure_default_remember_me`) is enabled, Microsoft Entra ID may be
 refusing to reuse sign-in sessions created by the Chrome for Testing browser
 bundled with Puppeteer, even though the session cookies are saved and sent
-correctly. Point az2aws at your regular Chrome installation with a dedicated
-automation profile:
-
-    # macOS
-    export BROWSER_CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-    export BROWSER_USER_DATA_DIR="$HOME/.aws/chrome-profile"
-
-The first login still asks for your credentials; subsequent logins reuse the
-Entra session until it expires. Keep `BROWSER_USER_DATA_DIR` pointed at a
-dedicated directory (not your day-to-day Chrome profile) so az2aws never
-locks or modifies your normal browser data.
+correctly. az2aws avoids this by automatically preferring your system Chrome
+or Edge when one is installed (see "Browser Selection"). If no system browser
+was detected, or you opted out with `BROWSER_USE_SYSTEM_CHROME=0`, install
+Google Chrome or point `BROWSER_CHROME_BIN` at a Chromium-based browser.
+After switching browsers, the first login asks for your credentials once;
+subsequent logins reuse the Entra session until it expires.
 
 If your Microsoft account requires a saved passkey prompt before the username
 or password page appears, that flow is unsupported in `az2aws --mode cli`.

--- a/README.md
+++ b/README.md
@@ -297,6 +297,22 @@ If you see device compliance errors (e.g., "Device UnSecured Or Non-Compliant"),
 Try:
 `--mode gui` and use your system Chrome via `BROWSER_CHROME_BIN`.
 
+If you are prompted for your password on every login even though "Stay logged
+in" (`azure_default_remember_me`) is enabled, Microsoft Entra ID may be
+refusing to reuse sign-in sessions created by the Chrome for Testing browser
+bundled with Puppeteer, even though the session cookies are saved and sent
+correctly. Point az2aws at your regular Chrome installation with a dedicated
+automation profile:
+
+    # macOS
+    export BROWSER_CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    export BROWSER_USER_DATA_DIR="$HOME/.aws/chrome-profile"
+
+The first login still asks for your credentials; subsequent logins reuse the
+Entra session until it expires. Keep `BROWSER_USER_DATA_DIR` pointed at a
+dedicated directory (not your day-to-day Chrome profile) so az2aws never
+locks or modifies your normal browser data.
+
 If your Microsoft account requires a saved passkey prompt before the username
 or password page appears, that flow is unsupported in `az2aws --mode cli`.
 The prompt is rendered by the browser/OS passkey UI instead of the page DOM,

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -128,6 +128,10 @@ function clearAzureEnv() {
   }
 }
 
+function createEnoentError(): NodeJS.ErrnoException {
+  return Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+}
+
 describe("login", () => {
   describe("_loadProfileFromEnv", () => {
     const originalEnv = process.env;
@@ -2261,7 +2265,7 @@ describe("login", () => {
 
     it("should create a temporary profile with certificate auto-select in headless mode", async () => {
       mockFsMkdtemp.mockResolvedValueOnce("/tmp/az2aws-chromium-test");
-      mockFsReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+      mockFsReadFile.mockRejectedValueOnce(createEnoentError());
 
       try {
         await login._performLoginAsync(
@@ -2304,7 +2308,7 @@ describe("login", () => {
       (paths as any).userDataDir = "/custom/user/data/dir";
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (paths as any).profileDir = undefined;
-      mockFsReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+      mockFsReadFile.mockRejectedValueOnce(createEnoentError());
 
       try {
         await login._performLoginAsync(
@@ -2910,6 +2914,7 @@ describe("login", () => {
       vi.spyOn(console, "warn").mockImplementation(() => {});
       mockFsRm.mockResolvedValue(undefined);
       mockFsMkdir.mockResolvedValue(undefined);
+      mockFsReadFile.mockRejectedValue(createEnoentError());
       Object.keys(paths).forEach((key) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (paths as any)[key] = (originalPaths as any)[key];
@@ -4281,7 +4286,7 @@ describe("configureAutomaticCertificateSelectionAsync", () => {
   };
 
   it("should seed the auto-select preference when the preferences file is missing", async () => {
-    mockFsReadFile.mockRejectedValue(new Error("ENOENT"));
+    mockFsReadFile.mockRejectedValue(createEnoentError());
 
     await configureAutomaticCertificateSelectionAsync(
       "/data/dir",
@@ -4391,6 +4396,109 @@ describe("configureAutomaticCertificateSelectionAsync", () => {
       false,
     );
 
+    expect(mockFsWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("should append to existing user-managed entries instead of replacing them", async () => {
+    const userEntry = JSON.stringify({
+      pattern: "https://example.com",
+      filter: {},
+    });
+    mockFsReadFile.mockResolvedValue(
+      JSON.stringify({
+        profile: { managed_auto_select_certificate_for_urls: [userEntry] },
+      }),
+    );
+
+    await configureAutomaticCertificateSelectionAsync(
+      "/data/dir",
+      "Default",
+      true,
+    );
+
+    const { preferences } = readWrittenPreferences();
+    expect(
+      preferences.profile.managed_auto_select_certificate_for_urls,
+    ).toEqual([
+      userEntry,
+      JSON.stringify({
+        pattern: "https://[*.]microsoftonline.com",
+        filter: {},
+      }),
+    ]);
+  });
+
+  it("should not rewrite the preferences file when already seeded", async () => {
+    mockFsReadFile.mockResolvedValue(
+      JSON.stringify({
+        profile: {
+          managed_auto_select_certificate_for_urls: [
+            JSON.stringify({
+              pattern: "https://[*.]microsoftonline.com",
+              filter: {},
+            }),
+          ],
+        },
+      }),
+    );
+
+    await configureAutomaticCertificateSelectionAsync(
+      "/data/dir",
+      "Default",
+      true,
+    );
+
+    expect(mockFsWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("should keep user-managed entries when removing the seeded entry", async () => {
+    const userEntry = JSON.stringify({
+      pattern: "https://example.com",
+      filter: {},
+    });
+    mockFsReadFile.mockResolvedValue(
+      JSON.stringify({
+        profile: {
+          managed_auto_select_certificate_for_urls: [
+            userEntry,
+            JSON.stringify({
+              pattern: "https://[*.]microsoftonline.com",
+              filter: {},
+            }),
+          ],
+        },
+      }),
+    );
+
+    await configureAutomaticCertificateSelectionAsync(
+      "/data/dir",
+      "Default",
+      false,
+    );
+
+    const { preferences } = readWrittenPreferences();
+    expect(
+      preferences.profile.managed_auto_select_certificate_for_urls,
+    ).toEqual([userEntry]);
+  });
+
+  it("should fail without writing when the preferences file is unreadable", async () => {
+    mockFsReadFile.mockRejectedValue(
+      Object.assign(new Error("EACCES"), { code: "EACCES" }),
+    );
+
+    await expect(
+      configureAutomaticCertificateSelectionAsync("/data/dir", "Default", true),
+    ).rejects.toThrow("EACCES");
+    expect(mockFsWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("should fail without writing when the preferences file is corrupted", async () => {
+    mockFsReadFile.mockResolvedValue("{not valid json");
+
+    await expect(
+      configureAutomaticCertificateSelectionAsync("/data/dir", "Default", true),
+    ).rejects.toThrow();
     expect(mockFsWriteFile).not.toHaveBeenCalled();
   });
 });

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -32,6 +32,8 @@ const {
   mockFsMkdtemp,
   mockFsReadFile,
   mockFsWriteFile,
+  mockDetectSystemChrome,
+  mockIsSystemChromeDetectionDisabled,
 } = vi.hoisted(() => {
   const mockSend = vi.fn();
   const mockHttpsProxyAgent = vi.fn();
@@ -41,6 +43,8 @@ const {
   const mockFsMkdtemp = vi.fn();
   const mockFsReadFile = vi.fn();
   const mockFsWriteFile = vi.fn();
+  const mockDetectSystemChrome = vi.fn();
+  const mockIsSystemChromeDetectionDisabled = vi.fn();
   return {
     mockSend,
     mockHttpsProxyAgent,
@@ -50,6 +54,8 @@ const {
     mockFsMkdtemp,
     mockFsReadFile,
     mockFsWriteFile,
+    mockDetectSystemChrome,
+    mockIsSystemChromeDetectionDisabled,
   };
 });
 
@@ -83,6 +89,13 @@ vi.mock("fs/promises", () => ({
 
 vi.mock("node:timers/promises", () => ({
   setTimeout: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Default behavior (both mocks return undefined): detection enabled but no
+// system browser found, so tests exercise the bundled-browser path.
+vi.mock("./systemChrome", () => ({
+  detectSystemChromeAsync: mockDetectSystemChrome,
+  isSystemChromeDetectionDisabled: mockIsSystemChromeDetectionDisabled,
 }));
 
 import inquirer from "inquirer";
@@ -2092,6 +2105,157 @@ describe("login", () => {
             "--profile-directory=CustomProfile",
           ]),
         }),
+      );
+    });
+
+    it("should use an auto-detected system browser when BROWSER_CHROME_BIN is not set", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (paths as any).chromeBin = undefined;
+      mockDetectSystemChrome.mockResolvedValueOnce(
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      );
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      // The shared launch mock throws, which triggers the bundled-browser
+      // fallback and strips executablePath from the (shared) launch params
+      // object, so snapshot the value passed to each launch call instead.
+      const executablePathPerLaunch: (string | undefined)[] = [];
+      mockPuppeteerLaunch.mockImplementation(
+        (params: { executablePath?: string }) => {
+          executablePathPerLaunch.push(params.executablePath);
+          throw new Error("Mock launch error for testing");
+        },
+      );
+
+      try {
+        await login._performLoginAsync(
+          "https://login.example.com",
+          false,
+          false,
+          false,
+          false,
+          false,
+          "",
+          undefined,
+          false,
+          false,
+          false,
+          false,
+        );
+      } catch {
+        // Expected to throw
+      }
+
+      expect(executablePathPerLaunch[0]).toBe(
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Falling back to the bundled browser"),
+      );
+    });
+
+    it("should prefer BROWSER_CHROME_BIN over the auto-detected browser", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (paths as any).chromeBin = "/custom/chrome";
+
+      try {
+        await login._performLoginAsync(
+          "https://login.example.com",
+          false,
+          false,
+          false,
+          false,
+          false,
+          "",
+          undefined,
+          false,
+          false,
+          false,
+          false,
+        );
+      } catch {
+        // Expected to throw
+      }
+
+      expect(mockDetectSystemChrome).not.toHaveBeenCalled();
+      expect(capturedLaunchArgs).toEqual(
+        expect.objectContaining({ executablePath: "/custom/chrome" }),
+      );
+    });
+
+    it("should skip auto-detection when it is disabled", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (paths as any).chromeBin = undefined;
+      mockIsSystemChromeDetectionDisabled.mockReturnValueOnce(true);
+
+      try {
+        await login._performLoginAsync(
+          "https://login.example.com",
+          false,
+          false,
+          false,
+          false,
+          false,
+          "",
+          undefined,
+          false,
+          false,
+          false,
+          false,
+        );
+      } catch {
+        // Expected to throw
+      }
+
+      expect(mockDetectSystemChrome).not.toHaveBeenCalled();
+      expect(capturedLaunchArgs).not.toEqual(
+        expect.objectContaining({ executablePath: expect.anything() }),
+      );
+    });
+
+    it("should fall back to the bundled browser when the system browser fails to launch", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (paths as any).chromeBin = undefined;
+      mockDetectSystemChrome.mockResolvedValueOnce("/detected/system/chrome");
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const executablePathPerLaunch: (string | undefined)[] = [];
+      mockPuppeteerLaunch.mockImplementation(
+        (params: { executablePath?: string }) => {
+          executablePathPerLaunch.push(params.executablePath);
+          throw new Error("Mock launch error for testing");
+        },
+      );
+
+      try {
+        await login._performLoginAsync(
+          "https://login.example.com",
+          false,
+          false,
+          false,
+          false,
+          false,
+          "",
+          undefined,
+          false,
+          false,
+          false,
+          false,
+        );
+      } catch {
+        // Expected to throw after the bundled-browser retry also fails
+      }
+
+      expect(executablePathPerLaunch).toEqual([
+        "/detected/system/chrome",
+        undefined,
+      ]);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Falling back to the bundled browser"),
       );
     });
 

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { login } from "./login";
+import nodePath from "path";
+import {
+  login,
+  isCertificateAuthRequest,
+  configureAutomaticCertificateSelectionAsync,
+} from "./login";
 import { CLIError } from "./CLIError";
 
 vi.mock("inquirer", () => ({
@@ -24,18 +29,27 @@ const {
   mockPuppeteerLaunch,
   mockFsMkdir,
   mockFsRm,
+  mockFsMkdtemp,
+  mockFsReadFile,
+  mockFsWriteFile,
 } = vi.hoisted(() => {
   const mockSend = vi.fn();
   const mockHttpsProxyAgent = vi.fn();
   const mockPuppeteerLaunch = vi.fn();
   const mockFsMkdir = vi.fn();
   const mockFsRm = vi.fn();
+  const mockFsMkdtemp = vi.fn();
+  const mockFsReadFile = vi.fn();
+  const mockFsWriteFile = vi.fn();
   return {
     mockSend,
     mockHttpsProxyAgent,
     mockPuppeteerLaunch,
     mockFsMkdir,
     mockFsRm,
+    mockFsMkdtemp,
+    mockFsReadFile,
+    mockFsWriteFile,
   };
 });
 
@@ -61,6 +75,9 @@ vi.mock("fs/promises", () => ({
   default: {
     rm: mockFsRm,
     mkdir: mockFsMkdir,
+    mkdtemp: mockFsMkdtemp,
+    readFile: mockFsReadFile,
+    writeFile: mockFsWriteFile,
   },
 }));
 
@@ -2078,6 +2095,103 @@ describe("login", () => {
       );
     });
 
+    it("should create a temporary profile with certificate auto-select in headless mode", async () => {
+      mockFsMkdtemp.mockResolvedValueOnce("/tmp/az2aws-chromium-test");
+      mockFsReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+
+      try {
+        await login._performLoginAsync(
+          "https://login.example.com",
+          true, // headless
+          false,
+          false,
+          false,
+          false,
+          "",
+          undefined,
+          false,
+          false, // rememberMe
+          false,
+          false,
+        );
+      } catch {
+        // Expected to throw
+      }
+
+      expect(capturedLaunchArgs).toEqual(
+        expect.objectContaining({
+          args: expect.arrayContaining([
+            "--user-data-dir=/tmp/az2aws-chromium-test",
+          ]),
+        }),
+      );
+      expect(mockFsWriteFile).toHaveBeenCalledWith(
+        "/tmp/az2aws-chromium-test/Default/Preferences",
+        expect.stringContaining("managed_auto_select_certificate_for_urls"),
+      );
+      expect(mockFsRm).toHaveBeenCalledWith(
+        "/tmp/az2aws-chromium-test",
+        expect.objectContaining({ recursive: true, force: true }),
+      );
+    });
+
+    it("should seed certificate auto-select into the persistent profile in headless mode with rememberMe", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (paths as any).userDataDir = "/custom/user/data/dir";
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (paths as any).profileDir = undefined;
+      mockFsReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+
+      try {
+        await login._performLoginAsync(
+          "https://login.example.com",
+          true, // headless
+          false,
+          false,
+          false,
+          false,
+          "",
+          undefined,
+          false,
+          true, // rememberMe
+          false,
+          false,
+        );
+      } catch {
+        // Expected to throw
+      }
+
+      expect(mockFsMkdtemp).not.toHaveBeenCalled();
+      expect(mockFsWriteFile).toHaveBeenCalledWith(
+        "/custom/user/data/dir/Default/Preferences",
+        expect.stringContaining("managed_auto_select_certificate_for_urls"),
+      );
+    });
+
+    it("should not create a temporary profile in headful mode without rememberMe", async () => {
+      try {
+        await login._performLoginAsync(
+          "https://login.example.com",
+          false, // headless
+          false,
+          false,
+          false,
+          false,
+          "",
+          undefined,
+          false,
+          false, // rememberMe
+          false,
+          false,
+        );
+      } catch {
+        // Expected to throw
+      }
+
+      expect(mockFsMkdtemp).not.toHaveBeenCalled();
+      expect(mockFsWriteFile).not.toHaveBeenCalled();
+    });
+
     it("should ignore saved profile arguments when incognito=true and rememberMe=true", async () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2695,17 +2809,24 @@ describe("login", () => {
         maxRetries: 5,
         retryDelay: 100,
       });
-      expect(mockFsMkdir).toHaveBeenCalledTimes(2);
+      expect(mockFsMkdir).toHaveBeenCalledTimes(3);
       expect(mockFsMkdir).toHaveBeenNthCalledWith(1, "/mock/chromium/path", {
         recursive: true,
       });
-      expect(mockFsMkdir).toHaveBeenNthCalledWith(2, "/mock/chromium/path", {
+      // The second mkdir creates the profile directory holding the
+      // Preferences file used for certificate auto-selection.
+      expect(mockFsMkdir).toHaveBeenNthCalledWith(
+        2,
+        nodePath.join("/mock/chromium/path", "Default"),
+        { recursive: true },
+      );
+      expect(mockFsMkdir).toHaveBeenNthCalledWith(3, "/mock/chromium/path", {
         recursive: true,
       });
       expect(mockFsRm.mock.invocationCallOrder[0]).toBeGreaterThan(
         mockFsMkdir.mock.invocationCallOrder[0],
       );
-      expect(mockFsMkdir.mock.invocationCallOrder[1]).toBeGreaterThan(
+      expect(mockFsMkdir.mock.invocationCallOrder[2]).toBeGreaterThan(
         mockFsRm.mock.invocationCallOrder[0],
       );
       // Verify puppeteer.launch was called twice (initial + retry)
@@ -2762,7 +2883,7 @@ describe("login", () => {
           retryDelay: 100,
         },
       );
-      expect(mockFsMkdir).toHaveBeenCalledTimes(2);
+      expect(mockFsMkdir).toHaveBeenCalledTimes(3);
       expect(mockFsMkdir).toHaveBeenNthCalledWith(
         1,
         "C:\\Users\\alice\\.aws\\chromium",
@@ -2772,6 +2893,13 @@ describe("login", () => {
       );
       expect(mockFsMkdir).toHaveBeenNthCalledWith(
         2,
+        nodePath.join("C:\\Users\\alice\\.aws\\chromium", "Default"),
+        {
+          recursive: true,
+        },
+      );
+      expect(mockFsMkdir).toHaveBeenNthCalledWith(
+        3,
         "C:\\Users\\alice\\.aws\\chromium",
         {
           recursive: true,
@@ -2780,7 +2908,7 @@ describe("login", () => {
       expect(mockFsRm.mock.invocationCallOrder[0]).toBeGreaterThan(
         mockFsMkdir.mock.invocationCallOrder[0],
       );
-      expect(mockFsMkdir.mock.invocationCallOrder[1]).toBeGreaterThan(
+      expect(mockFsMkdir.mock.invocationCallOrder[2]).toBeGreaterThan(
         mockFsRm.mock.invocationCallOrder[0],
       );
       expect(mockPuppeteerLaunch).toHaveBeenCalledTimes(2);
@@ -3641,6 +3769,69 @@ describe("login", () => {
       expect(continueMocks[2]).toHaveBeenCalled();
     });
 
+    it("should warn once when certificate-based authentication is detected", async () => {
+      const mockPage = createMockPage();
+      const mockBrowser = createMockBrowser(mockPage);
+      mockPuppeteerLaunch.mockResolvedValue(mockBrowser);
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const certContinue = vi.fn().mockResolvedValue(undefined);
+
+      const promise = login._performLoginAsync(
+        "https://login.example.com",
+        true, // headless
+        false,
+        false, // cliProxy=false
+        false,
+        false,
+        "",
+        undefined,
+        false,
+        false,
+        false,
+        false,
+      );
+
+      await mockPage.waitForRequestInterception();
+
+      const requestHandler = mockPage.getRequestHandler();
+      if (requestHandler) {
+        requestHandler({
+          url: () =>
+            "https://certauth.login.microsoftonline.com/tenant-id/certauth",
+          postData: () => undefined,
+          respond: vi.fn(),
+          continue: certContinue,
+        });
+        requestHandler({
+          url: () => "https://device.login.microsoftonline.com/probe",
+          postData: () => undefined,
+          respond: vi.fn(),
+          continue: vi.fn().mockResolvedValue(undefined),
+        });
+        requestHandler({
+          url: () => "https://signin.aws.amazon.com/saml",
+          postData: () => "SAMLResponse=validSamlResponse",
+          respond: vi.fn().mockResolvedValue(undefined),
+          continue: vi.fn(),
+        });
+      }
+
+      const result = await promise;
+      expect(result).toBe("validSamlResponse");
+
+      const certificateWarnings = consoleWarnSpy.mock.calls.filter(
+        ([message]) =>
+          String(message).includes("Certificate-based authentication detected"),
+      );
+      expect(certificateWarnings).toHaveLength(1);
+      expect(String(certificateWarnings[0][0])).toContain("--mode debug");
+      // The certificate auth request itself must still be continued.
+      expect(certContinue).toHaveBeenCalled();
+    });
+
     it("should tolerate rejected continue promise before a later SAML response", async () => {
       const mockPage = createMockPage();
       const mockBrowser = createMockBrowser(mockPage);
@@ -3852,5 +4043,183 @@ describe("login", () => {
       expect(error).toBe(assumeRoleError);
       expect((error as Error).message).toBe("STS assume role failed");
     });
+  });
+});
+
+describe("isCertificateAuthRequest", () => {
+  it("should detect the Entra certificate authentication host", () => {
+    expect(
+      isCertificateAuthRequest(
+        "https://certauth.login.microsoftonline.com/tenant-id/certauth",
+      ),
+    ).toBe(true);
+  });
+
+  it("should detect tenant-prefixed certificate authentication hosts", () => {
+    expect(
+      isCertificateAuthRequest(
+        "https://t1234.certauth.login.microsoftonline.com/tenant-id/certauth",
+      ),
+    ).toBe(true);
+  });
+
+  it("should detect the device certificate authentication host", () => {
+    expect(
+      isCertificateAuthRequest(
+        "https://device.login.microsoftonline.com/some/path",
+      ),
+    ).toBe(true);
+  });
+
+  it("should not match the regular login host", () => {
+    expect(
+      isCertificateAuthRequest(
+        "https://login.microsoftonline.com/common/oauth2",
+      ),
+    ).toBe(false);
+  });
+
+  it("should not match lookalike hosts or paths", () => {
+    expect(
+      isCertificateAuthRequest(
+        "https://evil.example.com/certauth.login.microsoftonline.com",
+      ),
+    ).toBe(false);
+    expect(
+      isCertificateAuthRequest(
+        "https://xcertauth.login.microsoftonline.com/certauth",
+      ),
+    ).toBe(false);
+  });
+
+  it("should return false for invalid URLs", () => {
+    expect(isCertificateAuthRequest("not a url")).toBe(false);
+  });
+});
+
+describe("configureAutomaticCertificateSelectionAsync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFsMkdir.mockResolvedValue(undefined);
+    mockFsWriteFile.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const readWrittenPreferences = () => {
+    const [writtenPath, writtenContent] = mockFsWriteFile.mock.calls[0] as [
+      string,
+      string,
+    ];
+    return { writtenPath, preferences: JSON.parse(writtenContent) };
+  };
+
+  it("should seed the auto-select preference when the preferences file is missing", async () => {
+    mockFsReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    await configureAutomaticCertificateSelectionAsync(
+      "/data/dir",
+      "Default",
+      true,
+    );
+
+    expect(mockFsMkdir).toHaveBeenCalledWith("/data/dir/Default", {
+      recursive: true,
+    });
+    const { writtenPath, preferences } = readWrittenPreferences();
+    expect(writtenPath).toBe("/data/dir/Default/Preferences");
+    expect(
+      preferences.profile.managed_auto_select_certificate_for_urls,
+    ).toEqual([
+      JSON.stringify({
+        pattern: "https://[*.]microsoftonline.com",
+        filter: {},
+      }),
+    ]);
+  });
+
+  it("should preserve existing preferences when seeding", async () => {
+    mockFsReadFile.mockResolvedValue(
+      JSON.stringify({
+        profile: { exit_type: "Normal" },
+        other_setting: 42,
+      }),
+    );
+
+    await configureAutomaticCertificateSelectionAsync(
+      "/data/dir",
+      "CustomProfile",
+      true,
+    );
+
+    const { writtenPath, preferences } = readWrittenPreferences();
+    expect(writtenPath).toBe("/data/dir/CustomProfile/Preferences");
+    expect(preferences.profile.exit_type).toBe("Normal");
+    expect(preferences.other_setting).toBe(42);
+    expect(
+      preferences.profile.managed_auto_select_certificate_for_urls,
+    ).toBeDefined();
+  });
+
+  it("should remove a previously seeded preference when disabling", async () => {
+    mockFsReadFile.mockResolvedValue(
+      JSON.stringify({
+        profile: {
+          exit_type: "Normal",
+          managed_auto_select_certificate_for_urls: [
+            JSON.stringify({
+              pattern: "https://[*.]microsoftonline.com",
+              filter: {},
+            }),
+          ],
+        },
+      }),
+    );
+
+    await configureAutomaticCertificateSelectionAsync(
+      "/data/dir",
+      "Default",
+      false,
+    );
+
+    const { preferences } = readWrittenPreferences();
+    expect(
+      preferences.profile.managed_auto_select_certificate_for_urls,
+    ).toBeUndefined();
+    expect(preferences.profile.exit_type).toBe("Normal");
+  });
+
+  it("should not write when disabling and no preference was seeded", async () => {
+    mockFsReadFile.mockResolvedValue(JSON.stringify({ profile: {} }));
+
+    await configureAutomaticCertificateSelectionAsync(
+      "/data/dir",
+      "Default",
+      false,
+    );
+
+    expect(mockFsWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("should not remove a user-managed value it did not seed", async () => {
+    mockFsReadFile.mockResolvedValue(
+      JSON.stringify({
+        profile: {
+          managed_auto_select_certificate_for_urls: [
+            JSON.stringify({ pattern: "https://example.com", filter: {} }),
+          ],
+        },
+      }),
+    );
+
+    await configureAutomaticCertificateSelectionAsync(
+      "/data/dir",
+      "Default",
+      false,
+    );
+
+    expect(mockFsWriteFile).not.toHaveBeenCalled();
   });
 });

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -2290,7 +2290,7 @@ describe("login", () => {
         }),
       );
       expect(mockFsWriteFile).toHaveBeenCalledWith(
-        "/tmp/az2aws-chromium-test/Default/Preferences",
+        nodePath.join("/tmp/az2aws-chromium-test", "Default", "Preferences"),
         expect.stringContaining("managed_auto_select_certificate_for_urls"),
       );
       expect(mockFsRm).toHaveBeenCalledWith(
@@ -2327,7 +2327,7 @@ describe("login", () => {
 
       expect(mockFsMkdtemp).not.toHaveBeenCalled();
       expect(mockFsWriteFile).toHaveBeenCalledWith(
-        "/custom/user/data/dir/Default/Preferences",
+        nodePath.join("/custom/user/data/dir", "Default", "Preferences"),
         expect.stringContaining("managed_auto_select_certificate_for_urls"),
       );
     });
@@ -4289,11 +4289,16 @@ describe("configureAutomaticCertificateSelectionAsync", () => {
       true,
     );
 
-    expect(mockFsMkdir).toHaveBeenCalledWith("/data/dir/Default", {
-      recursive: true,
-    });
+    expect(mockFsMkdir).toHaveBeenCalledWith(
+      nodePath.join("/data/dir", "Default"),
+      {
+        recursive: true,
+      },
+    );
     const { writtenPath, preferences } = readWrittenPreferences();
-    expect(writtenPath).toBe("/data/dir/Default/Preferences");
+    expect(writtenPath).toBe(
+      nodePath.join("/data/dir", "Default", "Preferences"),
+    );
     expect(
       preferences.profile.managed_auto_select_certificate_for_urls,
     ).toEqual([
@@ -4319,7 +4324,9 @@ describe("configureAutomaticCertificateSelectionAsync", () => {
     );
 
     const { writtenPath, preferences } = readWrittenPreferences();
-    expect(writtenPath).toBe("/data/dir/CustomProfile/Preferences");
+    expect(writtenPath).toBe(
+      nodePath.join("/data/dir", "CustomProfile", "Preferences"),
+    );
     expect(preferences.profile.exit_type).toBe("Normal");
     expect(preferences.other_setting).toBe(42);
     expect(

--- a/src/login.ts
+++ b/src/login.ts
@@ -134,18 +134,17 @@ const AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY =
 // Chrome honors the AutoSelectCertificateForUrls enterprise policy through
 // this profile preference. [*.]microsoftonline.com covers the Entra ID
 // certificate authentication hosts (certauth.login / device.login).
-const AUTO_SELECT_CLIENT_CERTIFICATE_URLS = [
-  JSON.stringify({
-    pattern: "https://[*.]microsoftonline.com",
-    filter: {},
-  }),
-];
+const AUTO_SELECT_CERTIFICATE_PREFERENCE = JSON.stringify({
+  pattern: "https://[*.]microsoftonline.com",
+  filter: {},
+});
 
 /**
  * Chrome shows a native dialog when the IdP requests a client certificate,
  * which headless mode cannot display. Seeding this preference makes Chrome
- * auto-select the certificate instead of hanging. When disabling, only a seed
- * that az2aws itself wrote is removed so user-managed settings stay intact.
+ * auto-select the certificate instead of hanging. The az2aws entry is merged
+ * with (and later removed from) any existing entries so user-managed
+ * settings stay intact.
  */
 export async function configureAutomaticCertificateSelectionAsync(
   userDataDir: string,
@@ -163,11 +162,17 @@ export async function configureAutomaticCertificateSelectionAsync(
     const parsed: unknown = JSON.parse(
       await fs.readFile(preferencesPath, "utf8"),
     );
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      preferences = parsed as Record<string, unknown>;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Preferences file has an unexpected format");
     }
-  } catch {
-    // Missing or unreadable preferences; start from an empty file.
+    preferences = parsed as Record<string, unknown>;
+  } catch (error) {
+    // Only a missing file is safe to create from scratch. Any other failure
+    // (locked, unreadable, corrupted) could belong to a real Chrome profile
+    // that must not be overwritten, so bail out without writing.
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
   }
 
   const profileSection =
@@ -177,18 +182,34 @@ export async function configureAutomaticCertificateSelectionAsync(
       ? (preferences.profile as Record<string, unknown>)
       : {};
 
+  const existingValue = profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY];
+
   if (enabled) {
-    profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY] =
-      AUTO_SELECT_CLIENT_CERTIFICATE_URLS;
+    // Append the az2aws entry, keeping any user-managed entries. A non-array
+    // value is invalid for this preference and gets replaced.
+    const entries: unknown[] = Array.isArray(existingValue)
+      ? [...(existingValue as unknown[])]
+      : [];
+    if (entries.includes(AUTO_SELECT_CERTIFICATE_PREFERENCE)) {
+      return;
+    }
+    entries.push(AUTO_SELECT_CERTIFICATE_PREFERENCE);
+    profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY] = entries;
   } else {
-    const currentValue = profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY];
     if (
-      JSON.stringify(currentValue) !==
-      JSON.stringify(AUTO_SELECT_CLIENT_CERTIFICATE_URLS)
+      !Array.isArray(existingValue) ||
+      !existingValue.includes(AUTO_SELECT_CERTIFICATE_PREFERENCE)
     ) {
       return;
     }
-    delete profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY];
+    const remainingEntries = existingValue.filter(
+      (entry) => entry !== AUTO_SELECT_CERTIFICATE_PREFERENCE,
+    );
+    if (remainingEntries.length === 0) {
+      delete profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY];
+    } else {
+      profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY] = remainingEntries;
+    }
   }
 
   preferences.profile = profileSection;

--- a/src/login.ts
+++ b/src/login.ts
@@ -27,6 +27,10 @@ import {
   redactUrlForLogs,
   shouldAllowSensitiveOutput,
 } from "./sensitiveOutput";
+import {
+  detectSystemChromeAsync,
+  isSystemChromeDetectionDisabled,
+} from "./systemChrome";
 
 const debug = _debug("az2aws");
 
@@ -665,8 +669,16 @@ export const login = {
         ignoreDefaultArgs,
       };
 
+      let usingAutoDetectedBrowser = false;
       if (paths.chromeBin) {
         launchParams.executablePath = paths.chromeBin;
+      } else if (!isSystemChromeDetectionDisabled()) {
+        const systemChrome = await detectSystemChromeAsync();
+        if (systemChrome) {
+          debug(`Using system browser: ${systemChrome}`);
+          launchParams.executablePath = systemChrome;
+          usingAutoDetectedBrowser = true;
+        }
       }
 
       try {
@@ -691,6 +703,15 @@ export const login = {
             retryDelay: 100,
           });
           await fs.mkdir(paths.chromium, { recursive: true });
+          browser = await puppeteer.launch(launchParams);
+        } else if (usingAutoDetectedBrowser) {
+          debug(
+            `System browser launch failed: ${formatDebugErrorMessage(e)}. Falling back to the bundled browser.`,
+          );
+          console.warn(
+            "The system browser failed to launch. Falling back to the bundled browser...",
+          );
+          delete launchParams.executablePath;
           browser = await puppeteer.launch(launchParams);
         } else {
           throw e;

--- a/src/login.ts
+++ b/src/login.ts
@@ -12,6 +12,8 @@ import { CLIError } from "./CLIError";
 import { awsConfig, ProfileConfig, ProfileCredentials } from "./awsConfig";
 import { paths } from "./paths";
 import fs from "fs/promises";
+import os from "os";
+import path from "path";
 import { Agent } from "https";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { states } from "./loginStates";
@@ -93,6 +95,101 @@ function printGuiFallbackHint(): void {
   console.log(
     "Login is taking longer than expected. If a browser prompt such as certificate selection is waiting for input, stop this run and retry with --mode=gui.",
   );
+}
+
+// Entra ID performs certificate-based and device-certificate authentication on
+// dedicated hosts that request a TLS client certificate from the browser.
+export function isCertificateAuthRequest(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return (
+      hostname === "certauth.login.microsoftonline.com" ||
+      hostname.endsWith(".certauth.login.microsoftonline.com") ||
+      hostname === "device.login.microsoftonline.com"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function printCertificateAuthHint(headless: boolean): void {
+  if (headless) {
+    console.warn(
+      "Certificate-based authentication detected. az2aws will try to select a client certificate automatically. " +
+        "If the login stalls or fails, rerun with --mode debug or --mode gui and select the certificate in the browser window.",
+    );
+  } else {
+    console.warn(
+      "Certificate-based authentication detected. If the login stalls, check the browser window for a certificate selection dialog.",
+    );
+  }
+}
+
+const AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY =
+  "managed_auto_select_certificate_for_urls";
+// Chrome honors the AutoSelectCertificateForUrls enterprise policy through
+// this profile preference. [*.]microsoftonline.com covers the Entra ID
+// certificate authentication hosts (certauth.login / device.login).
+const AUTO_SELECT_CLIENT_CERTIFICATE_URLS = [
+  JSON.stringify({
+    pattern: "https://[*.]microsoftonline.com",
+    filter: {},
+  }),
+];
+
+/**
+ * Chrome shows a native dialog when the IdP requests a client certificate,
+ * which headless mode cannot display. Seeding this preference makes Chrome
+ * auto-select the certificate instead of hanging. When disabling, only a seed
+ * that az2aws itself wrote is removed so user-managed settings stay intact.
+ */
+export async function configureAutomaticCertificateSelectionAsync(
+  userDataDir: string,
+  profileDirectory: string,
+  enabled: boolean,
+): Promise<void> {
+  const preferencesPath = path.join(
+    userDataDir,
+    profileDirectory,
+    "Preferences",
+  );
+
+  let preferences: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = JSON.parse(
+      await fs.readFile(preferencesPath, "utf8"),
+    );
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      preferences = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Missing or unreadable preferences; start from an empty file.
+  }
+
+  const profileSection =
+    preferences.profile &&
+    typeof preferences.profile === "object" &&
+    !Array.isArray(preferences.profile)
+      ? (preferences.profile as Record<string, unknown>)
+      : {};
+
+  if (enabled) {
+    profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY] =
+      AUTO_SELECT_CLIENT_CERTIFICATE_URLS;
+  } else {
+    const currentValue = profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY];
+    if (
+      JSON.stringify(currentValue) !==
+      JSON.stringify(AUTO_SELECT_CLIENT_CERTIFICATE_URLS)
+    ) {
+      return;
+    }
+    delete profileSection[AUTO_SELECT_CERTIFICATE_PREFERENCE_KEY];
+  }
+
+  preferences.profile = profileSection;
+  await fs.mkdir(path.dirname(preferencesPath), { recursive: true });
+  await fs.writeFile(preferencesPath, JSON.stringify(preferences));
 }
 
 export const login = {
@@ -481,6 +578,7 @@ export const login = {
     debug("Loading login page in Chrome");
 
     let browser: Browser | undefined;
+    let temporaryUserDataDir: string | undefined;
     const useRememberMe = rememberMe && !incognito;
 
     try {
@@ -515,6 +613,31 @@ export const login = {
       if (incognito && rememberMe) {
         console.warn(
           "WARNING: Incognito mode overrides 'Stay logged in' and ignores saved Chrome profiles.",
+        );
+      }
+
+      try {
+        if (useRememberMe) {
+          await configureAutomaticCertificateSelectionAsync(
+            paths.userDataDir || paths.chromium,
+            paths.profileDir || "Default",
+            headless,
+          );
+        } else if (headless) {
+          const temporaryDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "az2aws-chromium-"),
+          );
+          temporaryUserDataDir = temporaryDir;
+          await configureAutomaticCertificateSelectionAsync(
+            temporaryDir,
+            "Default",
+            true,
+          );
+          args.push(`--user-data-dir=${temporaryDir}`);
+        }
+      } catch (error) {
+        debug(
+          `Unable to configure automatic certificate selection: ${formatDebugErrorMessage(error)}`,
         );
       }
 
@@ -599,11 +722,16 @@ export const login = {
 
       // Prevent redirection to AWS
       let samlResponseData;
+      let hasDetectedCertificateAuth = false;
       const samlResponsePromise = new Promise((resolve) => {
         page.on("request", (req: HTTPRequest) => {
           const reqURL = req.url();
           const redactedURL = redactUrlForLogs(reqURL);
           debug(`Request: ${redactedURL}`);
+          if (!hasDetectedCertificateAuth && isCertificateAuthRequest(reqURL)) {
+            hasDetectedCertificateAuth = true;
+            printCertificateAuthHint(headless);
+          }
           if (
             reqURL === AWS_SAML_ENDPOINT ||
             reqURL === AWS_GOV_SAML_ENDPOINT ||
@@ -668,6 +796,7 @@ export const login = {
           if (
             passwordSubmittedAt !== undefined &&
             !hasPrintedGuiFallbackHint &&
+            !hasDetectedCertificateAuth &&
             Date.now() - passwordSubmittedAt > GUI_FALLBACK_HINT_DELAY
           ) {
             printGuiFallbackHint();
@@ -767,6 +896,20 @@ export const login = {
     } finally {
       if (browser) {
         await browser.close();
+      }
+      if (temporaryUserDataDir) {
+        try {
+          await fs.rm(temporaryUserDataDir, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 100,
+          });
+        } catch (error) {
+          debug(
+            `Failed to remove temporary browser profile: ${formatDebugErrorMessage(error)}`,
+          );
+        }
       }
     }
   },

--- a/src/loginStates.test.ts
+++ b/src/loginStates.test.ts
@@ -656,8 +656,8 @@ describe("loginStates", () => {
 
       expect(consoleSpy).toHaveBeenCalledWith("Open your Authenticator app");
       expect(mockPage.waitForSelector).toHaveBeenCalledWith(
-        "#idRichContext_DisplaySign",
-        { visible: true, timeout: 5000 },
+        "#idRichContext_DisplaySign,#idRemoteNGC_DisplaySign",
+        { visible: true, timeout: 15000 },
       );
       expect(consoleSpy).toHaveBeenCalledWith("58");
       expect(mockPage.waitForSelector).toHaveBeenCalledWith(
@@ -674,13 +674,16 @@ describe("loginStates", () => {
 
       mockPage.evaluate.mockResolvedValue("Open your Authenticator app");
       mockPage.waitForSelector.mockImplementation((selector: string) => {
-        if (selector === "#idRichContext_DisplaySign") {
+        if (selector.includes("#idRichContext_DisplaySign")) {
           return Promise.reject(new Error("Timeout"));
         }
         return Promise.resolve(undefined);
       });
 
       const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
 
       await getTfaInstructionsState().handler(
         mockPage as never,
@@ -699,6 +702,46 @@ describe("loginStates", () => {
       );
 
       consoleSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("should warn visibly when the authentication code cannot be read", async () => {
+      const mockPage = createMockPage();
+      const mockSelectedElement = {};
+
+      mockPage.evaluate.mockResolvedValue("Open your Authenticator app");
+      mockPage.waitForSelector.mockImplementation((selector: string) => {
+        if (selector.includes("#idRichContext_DisplaySign")) {
+          return Promise.reject(new Error("Timeout"));
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      await getTfaInstructionsState().handler(
+        mockPage as never,
+        mockSelectedElement as never,
+        false,
+        "",
+        undefined,
+        false,
+      );
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Could not read the verification code from the sign-in page",
+        ),
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("--mode debug"),
+      );
+
+      consoleSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
   });
 

--- a/src/loginStates.ts
+++ b/src/loginStates.ts
@@ -41,6 +41,10 @@ async function readTextContent<T extends Node>(
 const PASSWORD_SELECTOR =
   'input[name="Password"]:not(.moveOffScreen),input[name="passwd"]:not(.moveOffScreen)';
 
+// The number-matching code element differs across Entra sign-in page variants.
+const TFA_DISPLAY_SIGN_SELECTOR =
+  "#idRichContext_DisplaySign,#idRemoteNGC_DisplaySign";
+
 function printPageMessage(message: string, allowSensitiveOutput = true): void {
   if (allowSensitiveOutput) {
     console.log(message);
@@ -320,13 +324,13 @@ export const states: State[] = [
 
       try {
         debug("Waiting for authentication code to be displayed");
-        await page.waitForSelector("#idRichContext_DisplaySign", {
+        await page.waitForSelector(TFA_DISPLAY_SIGN_SELECTOR, {
           visible: true,
-          timeout: 5000,
+          timeout: 15000,
         });
         debug("Checking if authentication code is displayed");
         const authenticationCodeElement = await page.$(
-          "#idRichContext_DisplaySign",
+          TFA_DISPLAY_SIGN_SELECTOR,
         );
         debug("Reading the authentication code");
         const authenticationCode = await readTextContent(
@@ -337,6 +341,10 @@ export const states: State[] = [
         printPageMessage(authenticationCode, allowSensitiveOutput);
       } catch {
         debug("No authentication code found on page");
+        console.warn(
+          "Could not read the verification code from the sign-in page. " +
+            "If your Authenticator app asks for a number, rerun az2aws with --mode debug or --mode gui to see it.",
+        );
       }
 
       debug("Waiting for response");

--- a/src/systemChrome.test.ts
+++ b/src/systemChrome.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockFsAccess } = vi.hoisted(() => ({ mockFsAccess: vi.fn() }));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    access: mockFsAccess,
+  },
+}));
+
+import {
+  detectSystemChromeAsync,
+  isSystemChromeDetectionDisabled,
+} from "./systemChrome";
+
+const CHROME_MAC =
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const EDGE_MAC =
+  "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge";
+
+describe("detectSystemChromeAsync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return Chrome on macOS when installed", async () => {
+    mockFsAccess.mockImplementation((candidate: string) =>
+      candidate === CHROME_MAC
+        ? Promise.resolve()
+        : Promise.reject(new Error("ENOENT")),
+    );
+
+    await expect(detectSystemChromeAsync("darwin", {})).resolves.toBe(
+      CHROME_MAC,
+    );
+  });
+
+  it("should fall back to Edge on macOS when Chrome is missing", async () => {
+    mockFsAccess.mockImplementation((candidate: string) =>
+      candidate === EDGE_MAC
+        ? Promise.resolve()
+        : Promise.reject(new Error("ENOENT")),
+    );
+
+    await expect(detectSystemChromeAsync("darwin", {})).resolves.toBe(EDGE_MAC);
+  });
+
+  it("should prefer Chrome over Edge when both are installed", async () => {
+    mockFsAccess.mockResolvedValue(undefined);
+
+    await expect(detectSystemChromeAsync("darwin", {})).resolves.toBe(
+      CHROME_MAC,
+    );
+  });
+
+  it("should return undefined when no browser is installed", async () => {
+    mockFsAccess.mockRejectedValue(new Error("ENOENT"));
+
+    await expect(
+      detectSystemChromeAsync("darwin", {}),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should detect Chrome on Linux", async () => {
+    mockFsAccess.mockImplementation((candidate: string) =>
+      candidate === "/usr/bin/google-chrome-stable"
+        ? Promise.resolve()
+        : Promise.reject(new Error("ENOENT")),
+    );
+
+    await expect(detectSystemChromeAsync("linux", {})).resolves.toBe(
+      "/usr/bin/google-chrome-stable",
+    );
+  });
+
+  it("should build Windows candidates from environment variables", async () => {
+    const env = {
+      PROGRAMFILES: "C:\\Program Files",
+      "PROGRAMFILES(X86)": "C:\\Program Files (x86)",
+      LOCALAPPDATA: "C:\\Users\\alice\\AppData\\Local",
+    };
+    mockFsAccess.mockImplementation((candidate: string) =>
+      candidate.includes("AppData") && candidate.endsWith("chrome.exe")
+        ? Promise.resolve()
+        : Promise.reject(new Error("ENOENT")),
+    );
+
+    const detected = await detectSystemChromeAsync("win32", env);
+    expect(detected).toContain("AppData");
+    expect(detected).toContain("chrome.exe");
+  });
+
+  it("should return undefined on Windows when no base directories are set", async () => {
+    mockFsAccess.mockRejectedValue(new Error("ENOENT"));
+
+    await expect(detectSystemChromeAsync("win32", {})).resolves.toBeUndefined();
+    expect(mockFsAccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("isSystemChromeDetectionDisabled", () => {
+  it("should be enabled by default", () => {
+    expect(isSystemChromeDetectionDisabled({})).toBe(false);
+  });
+
+  it.each(["0", "false", "FALSE"])(
+    "should be disabled when BROWSER_USE_SYSTEM_CHROME=%s",
+    (value) => {
+      expect(
+        isSystemChromeDetectionDisabled({ BROWSER_USE_SYSTEM_CHROME: value }),
+      ).toBe(true);
+    },
+  );
+
+  it("should stay enabled for other values", () => {
+    expect(
+      isSystemChromeDetectionDisabled({ BROWSER_USE_SYSTEM_CHROME: "1" }),
+    ).toBe(false);
+  });
+
+  it("should be disabled in CI environments", () => {
+    expect(isSystemChromeDetectionDisabled({ CI: "true" })).toBe(true);
+    expect(isSystemChromeDetectionDisabled({ GITHUB_ACTIONS: "true" })).toBe(
+      true,
+    );
+  });
+});

--- a/src/systemChrome.ts
+++ b/src/systemChrome.ts
@@ -1,0 +1,85 @@
+import { constants } from "fs";
+import fs from "fs/promises";
+import path from "path";
+import _debug from "debug";
+
+const debug = _debug("az2aws");
+
+// Entra ID can treat the bundled Chrome for Testing browser as untrusted
+// (e.g., refusing to reuse sign-in sessions), so prefer a real system
+// browser when one is installed. Chrome is preferred over Edge; both are
+// Chromium-based and work with the same launch options.
+const DARWIN_CANDIDATES = [
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+];
+
+const LINUX_CANDIDATES = [
+  "/usr/bin/google-chrome",
+  "/usr/bin/google-chrome-stable",
+  "/opt/google/chrome/chrome",
+  "/usr/bin/microsoft-edge",
+  "/usr/bin/chromium",
+  "/usr/bin/chromium-browser",
+];
+
+const WINDOWS_RELATIVE_CANDIDATES = [
+  path.join("Google", "Chrome", "Application", "chrome.exe"),
+  path.join("Microsoft", "Edge", "Application", "msedge.exe"),
+];
+
+function windowsCandidates(env: NodeJS.ProcessEnv): string[] {
+  const bases = [
+    env["PROGRAMFILES"],
+    env["PROGRAMFILES(X86)"],
+    env["LOCALAPPDATA"],
+  ].filter((base): base is string => !!base);
+
+  const candidates: string[] = [];
+  for (const relativeCandidate of WINDOWS_RELATIVE_CANDIDATES) {
+    for (const base of bases) {
+      candidates.push(path.join(base, relativeCandidate));
+    }
+  }
+  return candidates;
+}
+
+export function isSystemChromeDetectionDisabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const optOut = (env.BROWSER_USE_SYSTEM_CHROME || "").toLowerCase();
+  if (optOut === "0" || optOut === "false") {
+    return true;
+  }
+
+  // CI environments should keep using the pinned bundled browser for
+  // reproducibility.
+  return !!env.CI || !!env.GITHUB_ACTIONS;
+}
+
+export async function detectSystemChromeAsync(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | undefined> {
+  let candidates: string[];
+  if (platform === "darwin") {
+    candidates = DARWIN_CANDIDATES;
+  } else if (platform === "win32") {
+    candidates = windowsCandidates(env);
+  } else {
+    candidates = LINUX_CANDIDATES;
+  }
+
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate, constants.X_OK);
+      debug(`Detected system browser: ${candidate}`);
+      return candidate;
+    } catch {
+      // Not installed at this location; try the next candidate.
+    }
+  }
+
+  debug("No system browser detected; using the bundled browser");
+  return undefined;
+}


### PR DESCRIPTION
## Summary
When Microsoft Authenticator asks for a number-matching code, az2aws sometimes printed nothing to the terminal, and users were prompted for their password on every login even with "Stay logged in" enabled. Debugging against an affected tenant traced both regressions to the 2025-12 Puppeteer 13→24 upgrade, which replaced the old minimal headless implementation with the full-Chrome "new headless" and a newer Chrome for Testing build:

1. The "TFA instructions" state waited only 5 seconds for `#idRichContext_DisplaySign` and swallowed the failure with a debug-only log.
2. Tenants with certificate-based / device-certificate conditional access make Chrome show a *native* client-certificate picker between the password and MFA steps. The old headless silently continued without a certificate; the new headless waits for a picker that can never be shown, so the login stalled before reaching the MFA page.
3. Entra ID refuses to reuse sign-in sessions created by the Chrome for Testing browser — verified that the session cookies are saved, decryptable, and sent with no blocked reasons, yet Entra returns the bare username page; the same profile opened in the real Google Chrome signs in silently.

## Changes
Commit 1 — surface the code more reliably (`01094ba`):
- src/loginStates.ts: wait up to 15 seconds (was 5) for the number-matching element, also match the alternate `#idRemoteNGC_DisplaySign` ID, and print a visible `console.warn` with guidance when the code cannot be read

Commit 2 — handle certificate-based authentication in headless mode (`404fb34`):
- src/login.ts: in headless mode, seed the `AutoSelectCertificateForUrls` policy preference into the Chrome profile so the client certificate is selected automatically; disposable profile (cleaned up afterwards) when rememberMe is off; headful runs remove the seed only when it exactly matches the value az2aws wrote
- src/login.ts: detect requests to the Entra certificate-auth hosts and print an immediate, mode-specific hint

Commit 3 — prefer a real system browser (`f885499`, `96f910a`):
- src/systemChrome.ts: auto-detect a system Chrome (or Edge) at OS-standard locations on macOS/Windows/Linux and use it instead of the bundled Chrome for Testing; `BROWSER_CHROME_BIN` still takes precedence and `BROWSER_USE_SYSTEM_CHROME=0` opts out; detection is skipped in CI; launch failures fall back to the bundled browser
- README: new "Browser Selection" section and a troubleshooting entry for the every-login password prompt

## Concerns
- The certificate auto-select relies on Chrome honoring the managed pref read from the profile file; if a future Chrome stops honoring it, behavior degrades to the previous stall plus the new immediate hint.
- Auto-detection changes the default browser for users who have a system Chrome/Edge installed. The first login after switching re-prompts for credentials once (sessions do not transfer), after which "Stay logged in" works again — arguably better than today, where it never works. Users can pin the old behavior with `BROWSER_USE_SYSTEM_CHROME=0`.
- Tenants without certificate-based auth are unaffected by the cert changes; the seeded preference is inert unless a server requests a client certificate.

## Verification
- `pnpm lint`, `pnpm test` (285 passed, 32 new), `pnpm build` all green
- Verified end-to-end against a real Entra tenant requiring a device certificate: headless CLI mode previously stalled at the invisible certificate picker and prompted for the password on every login; with this PR the system Chrome is auto-detected and a warm profile signs in silently in ~1 second with no username/password/MFA prompts, and cold logins show the number-matching code in the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)